### PR TITLE
[codex] fix npx platform binary fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13583,7 +13583,7 @@
     },
     "packages/cli": {
       "name": "skillsgate",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -13764,7 +13764,7 @@
     },
     "packages/tui": {
       "name": "@skillsgate/tui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@opentui/core": "0.1.90",

--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -25,13 +25,33 @@ const binName = platform === "win32" ? "skillsgate-tui.exe" : "skillsgate-tui";
 const require = createRequire(import.meta.url);
 const thisDir = path.dirname(fileURLToPath(import.meta.url));
 
-function findBinary() {
+function getNpmGlobalRoot() {
+  try {
+    return execFileSync("npm", ["root", "-g"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function findBinary({ includeGlobal = false } = {}) {
   const candidates = [
     // Nested node_modules (local installs)
     () => require.resolve(`@skillsgate/${pkg}/${binName}`),
     // Sibling in global node_modules (npm install -g)
-    () => path.join(thisDir, "..", "..", "..", `@skillsgate/${pkg}`, binName),
+    () => path.join(thisDir, "..", "..", `@skillsgate/${pkg}`, binName),
   ];
+
+  if (includeGlobal) {
+    candidates.push(() => {
+      const globalRoot = getNpmGlobalRoot();
+      if (!globalRoot) throw new Error("npm global root not found");
+      return path.join(globalRoot, `@skillsgate/${pkg}`, binName);
+    });
+  }
 
   for (const resolve of candidates) {
     try {
@@ -54,15 +74,15 @@ if (!binPath) {
   console.error(`Installing platform binary (${fullPkg})...`);
   try {
     execSync(`npm install -g ${fullPkg} --no-save`, { stdio: "inherit", timeout: 30000 });
-    binPath = findBinary();
+    binPath = findBinary({ includeGlobal: true });
   } catch {
     // Fallback to latest if exact version is not published for this platform
     console.warn(`Could not install ${fullPkg}, falling back to @latest (versions may differ)`);
     try {
       execSync(`npm install -g @skillsgate/${pkg}@latest --no-save`, { stdio: "inherit", timeout: 30000 });
-      binPath = findBinary();
+      binPath = findBinary({ includeGlobal: true });
     } catch {
-      // fall through to error below
+      binPath = findBinary({ includeGlobal: true });
     }
   }
 }

--- a/packages/cli/bin/postinstall.mjs
+++ b/packages/cli/bin/postinstall.mjs
@@ -21,7 +21,7 @@ const pkg = platformMap[os.platform()]?.[os.arch()];
 if (!pkg) process.exit(0);
 
 // Check if already available as a sibling (optionalDeps worked)
-const siblingPath = path.join(thisDir, "..", "..", "..", `@skillsgate/${pkg}`);
+const siblingPath = path.join(thisDir, "..", "..", `@skillsgate/${pkg}`);
 if (fs.existsSync(siblingPath)) process.exit(0);
 
 // Also check nested node_modules

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillsgate",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Visual AI skill manager for all agents",
   "type": "module",
   "bin": {

--- a/packages/tui/bin/postinstall.cjs
+++ b/packages/tui/bin/postinstall.cjs
@@ -16,7 +16,7 @@ const pkg = platformMap[os.platform()]?.[os.arch()];
 if (!pkg) process.exit(0);
 
 // Check if already available as a sibling (optionalDeps worked)
-const siblingPath = path.join(__dirname, "..", "..", "..", `@skillsgate/${pkg}`);
+const siblingPath = path.join(__dirname, "..", "..", `@skillsgate/${pkg}`);
 if (fs.existsSync(siblingPath)) process.exit(0);
 
 // Also check nested node_modules
@@ -27,11 +27,20 @@ try {
 
 // Not found — install it explicitly
 const version = require("../package.json").version;
+const fullPkg = `@skillsgate/${pkg}@${version}`;
 try {
-  execSync(`npm install -g @skillsgate/${pkg}@${version} --no-save`, {
+  execSync(`npm install -g ${fullPkg} --no-save`, {
     stdio: "inherit",
     timeout: 30000,
   });
 } catch {
-  console.warn(`Warning: could not install @skillsgate/${pkg}. Run manually: npm install -g @skillsgate/${pkg}`);
+  console.warn(`Could not install ${fullPkg}, falling back to @latest (versions may differ)`);
+  try {
+    execSync(`npm install -g @skillsgate/${pkg}@latest --no-save`, {
+      stdio: "inherit",
+      timeout: 30000,
+    });
+  } catch {
+    console.warn(`Warning: could not install @skillsgate/${pkg}. Run manually: npm install -g @skillsgate/${pkg}`);
+  }
 }

--- a/packages/tui/bin/skillsgate-tui
+++ b/packages/tui/bin/skillsgate-tui
@@ -25,13 +25,33 @@ const binName = platform === "win32" ? "skillsgate-tui.exe" : "skillsgate-tui";
 const require = createRequire(import.meta.url);
 const thisDir = path.dirname(fileURLToPath(import.meta.url));
 
-function findBinary() {
+function getNpmGlobalRoot() {
+  try {
+    return execFileSync("npm", ["root", "-g"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function findBinary({ includeGlobal = false } = {}) {
   const candidates = [
     // Nested node_modules (local installs)
     () => require.resolve(`@skillsgate/${pkg}/${binName}`),
     // Sibling in global node_modules (npm install -g)
-    () => path.join(thisDir, "..", "..", "..", `@skillsgate/${pkg}`, binName),
+    () => path.join(thisDir, "..", "..", `@skillsgate/${pkg}`, binName),
   ];
+
+  if (includeGlobal) {
+    candidates.push(() => {
+      const globalRoot = getNpmGlobalRoot();
+      if (!globalRoot) throw new Error("npm global root not found");
+      return path.join(globalRoot, `@skillsgate/${pkg}`, binName);
+    });
+  }
 
   for (const resolve of candidates) {
     try {
@@ -54,9 +74,16 @@ if (!binPath) {
   console.error(`Installing platform binary (${fullPkg})...`);
   try {
     execSync(`npm install -g ${fullPkg}`, { stdio: "inherit", timeout: 30000 });
-    binPath = findBinary();
+    binPath = findBinary({ includeGlobal: true });
   } catch {
-    // fall through to error below
+    // Fallback to latest if exact version is not published for this platform
+    console.warn(`Could not install ${fullPkg}, falling back to @latest (versions may differ)`);
+    try {
+      execSync(`npm install -g @skillsgate/${pkg}@latest`, { stdio: "inherit", timeout: 30000 });
+      binPath = findBinary({ includeGlobal: true });
+    } catch {
+      binPath = findBinary({ includeGlobal: true });
+    }
   }
 }
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsgate/tui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "bin": {
     "skillsgate-tui": "bin/skillsgate-tui"


### PR DESCRIPTION
## Summary

Fixes #8.

This updates the `skillsgate` and legacy `@skillsgate/tui` launchers so `npx skillsgate` can recover when the wrapper package version is newer than the published platform binary package.

## Root Cause

`skillsgate@1.1.1` tried to install `@skillsgate/tui-darwin-arm64@1.1.1`, but the latest platform package was `0.2.0`. The fallback installed `@latest` globally, but the npx wrapper only searched its temporary install tree and also walked one directory too far for sibling `node_modules` lookup.

## Changes

- Correct sibling `node_modules/@skillsgate/...` platform package lookup.
- Resolve npm global root after explicit fallback installs, so `@latest` can be found from npx.
- Add the same exact-version-to-latest fallback to the legacy `@skillsgate/tui` wrapper.
- Bump release versions:
  - `skillsgate`: `1.1.1` -> `1.1.2`
  - `@skillsgate/tui`: `0.2.0` -> `0.2.1`

## Validation

- `node --check packages/cli/bin/cli.mjs`
- `node --check packages/cli/bin/postinstall.mjs`
- `node --check packages/tui/bin/skillsgate-tui`
- `node --check packages/tui/bin/postinstall.cjs`
- `npm run typecheck -w skillsgate`
- `npm run build -w skillsgate`
- `npm pack --dry-run -w skillsgate`
- `npm pack --dry-run -w @skillsgate/tui`
- Fallback simulation: exact platform package version fails, `@latest` installs, wrapper resolves the global binary and runs `--help`.

## Release Notes

After this lands on `main`, publish tags should be:

- `cli-v1.1.2`
- `tui-v0.2.1`
