### PR TITLE
fix(desktop,tui): restore favorites as local-first feature

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsgate/desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "SkillsGate desktop app for managing AI agent skills",
   "author": "Sultan Valiyev <valiyevsultan@gmail.com>",
   "homepage": "https://skillsgate.ai",

--- a/apps/desktop/src/main/db/favorites.ts
+++ b/apps/desktop/src/main/db/favorites.ts
@@ -1,0 +1,41 @@
+import type Database from "better-sqlite3"
+
+export class FavoritesStore {
+  private db: Database.Database
+
+  constructor(db: Database.Database) {
+    this.db = db
+  }
+
+  list(): string[] {
+    const rows = this.db
+      .prepare("SELECT skill_name FROM favorites ORDER BY created_at DESC")
+      .all() as Array<{ skill_name: string }>
+    return rows.map((r) => r.skill_name)
+  }
+
+  has(name: string): boolean {
+    const row = this.db
+      .prepare("SELECT 1 FROM favorites WHERE skill_name = ?")
+      .get(name)
+    return row !== undefined
+  }
+
+  toggle(name: string): boolean {
+    if (this.has(name)) {
+      this.db.prepare("DELETE FROM favorites WHERE skill_name = ?").run(name)
+      return false
+    }
+    this.db
+      .prepare("INSERT INTO favorites (skill_name) VALUES (?)")
+      .run(name)
+    return true
+  }
+
+  count(): number {
+    const row = this.db
+      .prepare("SELECT COUNT(*) as c FROM favorites")
+      .get() as { c: number }
+    return row.c
+  }
+}

--- a/apps/desktop/src/main/db/migrations.ts
+++ b/apps/desktop/src/main/db/migrations.ts
@@ -75,6 +75,17 @@ const MIGRATIONS: Migration[] = [
       INSERT OR IGNORE INTO schema_version VALUES (2);
     `,
   },
+  {
+    version: 3,
+    up: `
+      CREATE TABLE IF NOT EXISTS favorites (
+        skill_name TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      INSERT OR IGNORE INTO schema_version VALUES (3);
+    `,
+  },
 ]
 
 function getCurrentVersion(db: Database.Database): number {

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -9,6 +9,7 @@ import { openDb } from "./db/index"
 import { SettingsStore } from "./db/settings"
 import { RemoteServerStore } from "./db/servers"
 import { RemoteSkillStore } from "./db/skills"
+import { FavoritesStore } from "./db/favorites"
 import { loadCachedSkills, saveCachedSkills } from "./db/skills-cache"
 import { testConnection, syncRemoteServer, readRemoteFile, writeRemoteFile } from "./db/ssh"
 import { planPush, applyPush } from "./db/push"
@@ -1174,9 +1175,10 @@ async function installSkillToAgent(
 let settingsStore!: SettingsStore
 let serverStore!: RemoteServerStore
 let skillStore!: RemoteSkillStore
+let favoritesStore!: FavoritesStore
 
 function ensureStores(): void {
-  if (settingsStore && serverStore && skillStore) {
+  if (settingsStore && serverStore && skillStore && favoritesStore) {
     return
   }
 
@@ -1184,6 +1186,7 @@ function ensureStores(): void {
   settingsStore ??= new SettingsStore(db)
   serverStore ??= new RemoteServerStore(db)
   skillStore ??= new RemoteSkillStore(db)
+  favoritesStore ??= new FavoritesStore(db)
 }
 
 const COMMON_BIN_DIRS = [
@@ -1918,6 +1921,20 @@ Add your skill instructions here.
   ipcMain.handle("settings:all", () => {
     ensureStores()
     return settingsStore.getAll()
+  })
+
+  // -------------------------------------------------------------------------
+  // Favorites handlers
+  // -------------------------------------------------------------------------
+
+  ipcMain.handle("favorites:list", () => {
+    ensureStores()
+    return favoritesStore.list()
+  })
+
+  ipcMain.handle("favorites:toggle", (_event, name: string) => {
+    ensureStores()
+    return favoritesStore.toggle(name)
   })
 
   // -------------------------------------------------------------------------

--- a/apps/desktop/src/preload/api.d.ts
+++ b/apps/desktop/src/preload/api.d.ts
@@ -194,6 +194,10 @@ declare global {
     settingsSet: (key: string, value: unknown) => Promise<void>
     settingsAll: () => Promise<Record<string, unknown>>
 
+    // Favorites
+    favoritesList: () => Promise<string[]>
+    favoritesToggle: (name: string) => Promise<boolean>
+
     updatesGetState: () => Promise<UpdateState>
     updatesCheck: () => Promise<UpdateState>
     updatesInstall: () => Promise<void>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -103,6 +103,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.invoke("settings:set", key, value),
   settingsAll: () => ipcRenderer.invoke("settings:all"),
 
+  // Favorites
+  favoritesList: () => ipcRenderer.invoke("favorites:list"),
+  favoritesToggle: (name: string) =>
+    ipcRenderer.invoke("favorites:toggle", name),
+
   // Updates
   updatesGetState: () => ipcRenderer.invoke("updates:get-state"),
   updatesCheck: () => ipcRenderer.invoke("updates:check"),

--- a/apps/desktop/src/renderer/routes/home.tsx
+++ b/apps/desktop/src/renderer/routes/home.tsx
@@ -35,6 +35,29 @@ const DISPLAY_NAME_TO_KEY: Record<string, string> = {
   "Universal (.agents/skills)": "universal",
 }
 
+function StarIcon({
+  size = 14,
+  filled = false,
+}: {
+  size?: number
+  filled?: boolean
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  )
+}
+
 function SearchIcon({ size = 16 }: { size?: number }) {
   return (
     <svg
@@ -139,6 +162,7 @@ interface DragToast {
 
 interface LeftSidebarProps {
   totalSkillCount: number
+  favoritesCount: number
   agentsWithSkills: DetectedAgent[]
   agentSkillCounts: Record<string, number>
   selectedAgent: string | null
@@ -161,6 +185,7 @@ interface LeftSidebarProps {
 
 function LeftSidebar({
   totalSkillCount,
+  favoritesCount,
   agentsWithSkills,
   agentSkillCounts,
   selectedAgent,
@@ -224,7 +249,7 @@ function LeftSidebar({
                 activeFilter === "favorites" ? "text-foreground" : "text-muted"
               }`}
             >
-              0
+              {favoritesCount}
             </span>
           </button>
         </nav>
@@ -380,8 +405,10 @@ interface SkillRowProps {
   isMultiSelectActive: boolean
   selectedSkillPath: string | null
   dragSkill: DragSkillPayload | null
+  favorites: Set<string>
   onSelectSkill: (skill: InstalledSkill) => void
   onMultiSelectToggle: (skill: InstalledSkill, e: React.MouseEvent) => void
+  onToggleFavorite: (skill: InstalledSkill, e: React.MouseEvent) => void
   onDragSkillStart: (skill: InstalledSkill) => void
   onDragSkillEnd: () => void
 }
@@ -394,14 +421,17 @@ const SkillListRow = memo(function SkillListRow({
   isMultiSelectActive,
   selectedSkillPath,
   dragSkill,
+  favorites,
   onSelectSkill,
   onMultiSelectToggle,
+  onToggleFavorite,
   onDragSkillStart,
   onDragSkillEnd,
 }: SkillRowProps) {
   const skill = skills[index]
   if (!skill) return null
   const isMultiChecked = multiSelected.has(skill.canonicalPath)
+  const isFavorited = favorites.has(skill.name)
 
   return (
     <div style={style} className="px-0.5">
@@ -453,6 +483,27 @@ const SkillListRow = memo(function SkillListRow({
         <span className="text-[12px] font-medium truncate flex-1 min-w-0">
           {skill.name}
         </span>
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={isFavorited ? "Remove from favorites" : "Add to favorites"}
+          aria-pressed={isFavorited}
+          title={isFavorited ? "Remove from favorites" : "Add to favorites"}
+          onClick={(e) => onToggleFavorite(skill, e)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault()
+              onToggleFavorite(skill, e as unknown as React.MouseEvent)
+            }
+          }}
+          className={`ml-2 flex-shrink-0 inline-flex items-center justify-center w-5 h-5 rounded transition-colors cursor-pointer ${
+            isFavorited
+              ? "text-amber-400 hover:text-amber-300"
+              : "text-muted hover:text-foreground"
+          }`}
+        >
+          <StarIcon size={13} filled={isFavorited} />
+        </span>
         <span className="ml-2 flex-shrink-0">
           <AgentLogoRow agents={skill.agents} size={14} />
         </span>
@@ -475,6 +526,7 @@ interface MiddlePanelProps {
   onSelectSkill: (skill: InstalledSkill) => void
   selectedAgent: string | null
   selectedCollection: string | null
+  activeFilter: "all" | "favorites"
   onClearFilters: () => void
   onCreateSkill: () => void
   dragSkill: DragSkillPayload | null
@@ -484,6 +536,8 @@ interface MiddlePanelProps {
   onMultiSelectToggle: (skill: InstalledSkill, e: React.MouseEvent) => void
   onMultiSelectAll: () => void
   onMultiSelectClear: () => void
+  favorites: Set<string>
+  onToggleFavorite: (skill: InstalledSkill, e: React.MouseEvent) => void
   collections: Record<string, string[]>
   onBulkAddToCollection: (collectionName: string) => void
   onBulkCreateCollection: () => void
@@ -501,6 +555,7 @@ function MiddlePanel({
   onSelectSkill,
   selectedAgent,
   selectedCollection,
+  activeFilter,
   onClearFilters,
   onCreateSkill,
   dragSkill,
@@ -510,6 +565,8 @@ function MiddlePanel({
   onMultiSelectToggle,
   onMultiSelectAll,
   onMultiSelectClear,
+  favorites,
+  onToggleFavorite,
   collections,
   onBulkAddToCollection,
   onBulkCreateCollection,
@@ -526,8 +583,10 @@ function MiddlePanel({
       isMultiSelectActive,
       selectedSkillPath,
       dragSkill,
+      favorites,
       onSelectSkill,
       onMultiSelectToggle,
+      onToggleFavorite,
       onDragSkillStart,
       onDragSkillEnd,
     }),
@@ -537,8 +596,10 @@ function MiddlePanel({
       isMultiSelectActive,
       selectedSkillPath,
       dragSkill,
+      favorites,
       onSelectSkill,
       onMultiSelectToggle,
+      onToggleFavorite,
       onDragSkillStart,
       onDragSkillEnd,
     ],
@@ -638,6 +699,13 @@ function MiddlePanel({
                 </p>
                 <p className="text-muted text-[11px] mt-1">
                   Head to Discover to find skills.
+                </p>
+              </>
+            ) : activeFilter === "favorites" ? (
+              <>
+                <p className="text-muted text-[12px]">No favorites yet.</p>
+                <p className="text-muted text-[11px] mt-1">
+                  Click the star on any skill to save it here.
                 </p>
               </>
             ) : (
@@ -1484,6 +1552,7 @@ export function Home() {
   const deferredSearchQuery = useDeferredValue(searchQuery)
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
   const [activeFilter, setActiveFilter] = useState<"all" | "favorites">("all")
+  const [favorites, setFavorites] = useState<Set<string>>(new Set())
   const [selectedSkillPath, setSelectedSkillPath] = useState<string | null>(null)
   const [skillContent, setSkillContent] = useState<string | null>(null)
   const [contentLoading, setContentLoading] = useState(false)
@@ -1529,17 +1598,24 @@ export function Home() {
   useEffect(() => {
     async function load() {
       try {
-        const [detectedAgents, installedSkills, savedCollections, savedDefaultAgents] =
-          await Promise.all([
+        const [
+          detectedAgents,
+          installedSkills,
+          savedCollections,
+          savedDefaultAgents,
+          savedFavorites,
+        ] = await Promise.all([
           electronAPI.detectAgents(),
           electronAPI.listInstalled(),
           electronAPI.settingsGet("collections.skills", {} as Record<string, string[]>),
           electronAPI.settingsGet("install.defaultAgents", [] as string[]),
+          electronAPI.favoritesList(),
         ])
         setAgents(detectedAgents)
         setSkills(installedSkills)
         setCollections(savedCollections || {})
         setDefaultAgents(savedDefaultAgents || [])
+        setFavorites(new Set(savedFavorites))
       } catch (err) {
         console.error("Failed to load installed skills:", err)
       } finally {
@@ -1642,6 +1718,10 @@ export function Home() {
   const filteredSkills = useMemo(() => {
     let result = skills
 
+    if (activeFilter === "favorites") {
+      result = result.filter((s) => favorites.has(s.name))
+    }
+
     if (selectedCollection) {
       const ids = new Set(collections[selectedCollection] || [])
       result = result.filter((s) => ids.has(s.canonicalPath))
@@ -1668,7 +1748,15 @@ export function Home() {
     }
 
     return result
-  }, [skills, selectedAgent, deferredSearchQuery, selectedCollection, collections])
+  }, [
+    skills,
+    selectedAgent,
+    deferredSearchQuery,
+    selectedCollection,
+    collections,
+    activeFilter,
+    favorites,
+  ])
 
   const collectionCounts = useMemo(() => {
     const counts: Record<string, number> = {}
@@ -1684,9 +1772,49 @@ export function Home() {
     return agents.filter((a) => (agentSkillCounts[a.displayName] || 0) > 0)
   }, [agents, agentSkillCounts])
 
+  // Count favorites that are currently installed (orphan favorites are
+  // preserved in the DB but not shown in the sidebar count).
+  const installedFavoritesCount = useMemo(
+    () => skills.reduce((n, s) => (favorites.has(s.name) ? n + 1 : n), 0),
+    [skills, favorites],
+  )
+
   const handleSelectSkill = useCallback((skill: InstalledSkill) => {
     setSelectedSkillPath(skill.canonicalPath)
   }, [])
+
+  const handleToggleFavorite = useCallback(
+    async (skill: InstalledSkill, e: React.MouseEvent) => {
+      e.stopPropagation()
+      const name = skill.name
+      // Optimistic update
+      setFavorites((prev) => {
+        const next = new Set(prev)
+        if (next.has(name)) next.delete(name)
+        else next.add(name)
+        return next
+      })
+      try {
+        const isFavoritedAfter = await electronAPI.favoritesToggle(name)
+        setFavorites((prev) => {
+          const next = new Set(prev)
+          if (isFavoritedAfter) next.add(name)
+          else next.delete(name)
+          return next
+        })
+      } catch (err) {
+        console.error("Failed to toggle favorite:", err)
+        // Revert on failure
+        setFavorites((prev) => {
+          const next = new Set(prev)
+          if (next.has(name)) next.delete(name)
+          else next.add(name)
+          return next
+        })
+      }
+    },
+    [],
+  )
 
   const handleClearFilters = useCallback(() => {
     setSearchQuery("")
@@ -2074,6 +2202,7 @@ export function Home() {
       {/* Column 1: Left sidebar (filter panel) */}
       <MemoizedLeftSidebar
         totalSkillCount={skills.length}
+        favoritesCount={installedFavoritesCount}
         agentsWithSkills={agentsWithSkills}
         agentSkillCounts={agentSkillCounts}
         selectedAgent={selectedAgent}
@@ -2105,6 +2234,7 @@ export function Home() {
         onSelectSkill={handleSelectSkill}
         selectedAgent={selectedAgent}
         selectedCollection={selectedCollection}
+        activeFilter={activeFilter}
         onClearFilters={handleClearFilters}
         onCreateSkill={handleOpenCreateSkill}
         dragSkill={dragSkill}
@@ -2114,6 +2244,8 @@ export function Home() {
         onMultiSelectToggle={handleMultiSelectToggle}
         onMultiSelectAll={handleMultiSelectAll}
         onMultiSelectClear={handleMultiSelectClear}
+        favorites={favorites}
+        onToggleFavorite={handleToggleFavorite}
         collections={collections}
         onBulkAddToCollection={handleBulkAddToCollection}
         onBulkCreateCollection={handleBulkCreateCollection}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
     },
     "apps/desktop": {
       "name": "@skillsgate/desktop",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
@@ -13764,7 +13764,7 @@
     },
     "packages/tui": {
       "name": "@skillsgate/tui",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@opentui/core": "0.1.90",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skillsgate/tui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "bin": {
     "skillsgate-tui": "bin/skillsgate-tui"

--- a/packages/tui/src/components/agent-filter.tsx
+++ b/packages/tui/src/components/agent-filter.tsx
@@ -15,6 +15,12 @@ export function AgentFilter() {
   const { servers } = useDb()
 
   const allCount = state.installedSkills.length
+  // Count favorites that are currently installed.
+  const favSet = new Set(state.favorites)
+  const favoritesCount = state.installedSkills.reduce(
+    (n, s) => (favSet.has(s.name) ? n + 1 : n),
+    0,
+  )
 
   // Remote servers with skill counts
   const serverList = servers.list()
@@ -38,7 +44,7 @@ export function AgentFilter() {
     if (state.focusedPane !== "agents") return
     if (state.showHelp) return
 
-    const allOptions = ["all", ...agentOptions.map((o) => o.value)]
+    const allOptions = ["all", "favorites", ...agentOptions.map((o) => o.value)]
     const currentIdx = allOptions.indexOf(state.selectedAgentFilter)
 
     if (key.name === "up" || (key.name === "k" && !key.ctrl)) {
@@ -82,6 +88,21 @@ export function AgentFilter() {
           All Skills
         </text>
         <text fg={colors.textDim}> ({allCount})</text>
+      </box>
+
+      {/* Favorites */}
+      <box
+        style={{
+          paddingLeft: 1,
+          paddingRight: 1,
+          height: 1,
+          backgroundColor: state.selectedAgentFilter === "favorites" ? colors.bgAlt : "transparent",
+        }}
+      >
+        <text fg={state.selectedAgentFilter === "favorites" ? colors.primary : colors.text}>
+          {"★ "}Favorites
+        </text>
+        <text fg={colors.textDim}> ({favoritesCount})</text>
       </box>
 
       {/* Spacer */}

--- a/packages/tui/src/components/help-overlay.tsx
+++ b/packages/tui/src/components/help-overlay.tsx
@@ -10,6 +10,7 @@ const SHORTCUTS_LEFT: ShortcutEntry[] = [
   { key: "g", description: "Jump to first item" },
   { key: "G", description: "Jump to last item" },
   { key: "v", description: "View skill detail" },
+  { key: "f", description: "Toggle favorite on selected skill" },
   { key: "n", description: "Create local skill (home)" },
   { key: "c", description: "Manage collections (home)" },
   { key: "/", description: "Focus search input" },

--- a/packages/tui/src/components/layout.tsx
+++ b/packages/tui/src/components/layout.tsx
@@ -4,6 +4,7 @@ import { useStore, useDispatch } from "../store/context.js"
 import { useDb } from "../db/context.js"
 import { useDetectedAgents } from "../data/use-agents.js"
 import { useInstalledSkills } from "../data/use-installed-skills.js"
+import { useFavorites } from "../data/use-favorites.js"
 import { StatusBar } from "./status-bar.js"
 import { HelpOverlay } from "./help-overlay.js"
 import { HomeView } from "../views/home.js"
@@ -38,6 +39,7 @@ export function Layout() {
   // Load agent + skill data on mount
   useDetectedAgents()
   useInstalledSkills()
+  useFavorites()
 
   // Global keyboard shortcuts
   useKeyboard((key) => {

--- a/packages/tui/src/components/skill-list-item.tsx
+++ b/packages/tui/src/components/skill-list-item.tsx
@@ -4,13 +4,14 @@ import { colors, agentBadges as badgeMap } from "../utils/colors.js"
 interface SkillListItemProps {
   skill: EnrichedSkill
   selected?: boolean
+  favorited?: boolean
 }
 
 /**
  * Compact skill list item for the middle panel.
  * Shows just the name and small agent dot indicators.
  */
-export function SkillListItem({ skill, selected }: SkillListItemProps) {
+export function SkillListItem({ skill, selected, favorited }: SkillListItemProps) {
   // Build compact agent dots (single-char badges)
   const agentDots = skill.agents.slice(0, 3).map((a) => {
     const badge = badgeMap[a]
@@ -27,6 +28,11 @@ export function SkillListItem({ skill, selected }: SkillListItemProps) {
         backgroundColor: selected ? colors.bgAlt : "transparent",
       }}
     >
+      {/* Star indicator (favorited skills only) */}
+      <text fg={favorited ? colors.warning : colors.textDim}>
+        {favorited ? "★ " : "  "}
+      </text>
+
       {/* Skill name */}
       <text fg={selected ? colors.primary : colors.text} style={{ flexGrow: 1 }}>
         {skill.name}

--- a/packages/tui/src/components/skill-list.tsx
+++ b/packages/tui/src/components/skill-list.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useKeyboard } from "@opentui/react"
 import { useStore, useDispatch } from "../store/context.js"
 import { useSkillActions } from "../data/use-skill-actions.js"
+import { useFavorites } from "../data/use-favorites.js"
 import { SkillListItem } from "./skill-list-item.js"
 import { ConfirmDialog } from "./confirm-dialog.js"
 import { colors, agentBadges as badgeMap } from "../utils/colors.js"
@@ -30,6 +31,8 @@ export function SkillList({ skills }: SkillListProps) {
   const dispatch = useDispatch()
   const state = useStore()
   const { removeSkill, removeSkillFromOneAgent, updateSkill } = useSkillActions()
+  const { favorites, toggleFavorite } = useFavorites()
+  const favoritesSet = useMemo(() => new Set(favorites), [favorites])
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [pendingAction, setPendingAction] = useState<PendingAction>(null)
   const [removeMode, setRemoveMode] = useState<RemoveMode>(null)
@@ -113,6 +116,21 @@ export function SkillList({ skills }: SkillListProps) {
     // u to update selected skill
     if (key.name === "u" && skills[selectedIndex]) {
       setPendingAction({ type: "update", skill: skills[selectedIndex] })
+    }
+
+    // f to toggle favorite for selected skill
+    if (key.name === "f" && skills[selectedIndex]) {
+      const skill = skills[selectedIndex]
+      const isFavoritedAfter = toggleFavorite(skill.name)
+      dispatch({
+        type: "SHOW_NOTIFICATION",
+        notification: {
+          type: "info",
+          message: isFavoritedAfter
+            ? `Added "${skill.name}" to favorites`
+            : `Removed "${skill.name}" from favorites`,
+        },
+      })
     }
   })
 
@@ -201,7 +219,9 @@ export function SkillList({ skills }: SkillListProps) {
         <text fg={colors.textDim}>
           {state.installedLoading
             ? "Scanning for installed skills..."
-            : "No skills found. Install skills with: skillsgate install <source>"}
+            : state.selectedAgentFilter === "favorites"
+              ? "No favorites yet. Press f on any skill to save it here."
+              : "No skills found. Install skills with: skillsgate install <source>"}
         </text>
       </box>
     )
@@ -237,6 +257,7 @@ export function SkillList({ skills }: SkillListProps) {
             key={skill.name}
             skill={skill}
             selected={i === selectedIndex}
+            favorited={favoritesSet.has(skill.name)}
           />
         ))}
       </scrollbox>

--- a/packages/tui/src/data/use-favorites.ts
+++ b/packages/tui/src/data/use-favorites.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect } from "react"
+import { useDispatch, useStore } from "../store/context.js"
+import { useDb } from "../db/context.js"
+
+/**
+ * Hydrates the favorites list from the local DB on mount and exposes a
+ * `toggleFavorite` callback that updates both DB and store state.
+ */
+export function useFavorites() {
+  const dispatch = useDispatch()
+  const state = useStore()
+  const { favorites } = useDb()
+
+  useEffect(() => {
+    dispatch({ type: "SET_FAVORITES", favorites: favorites.list() })
+  }, [])
+
+  const toggleFavorite = useCallback(
+    (name: string): boolean => {
+      const next = favorites.toggle(name)
+      dispatch({ type: "SET_FAVORITES", favorites: favorites.list() })
+      return next
+    },
+    [favorites, dispatch],
+  )
+
+  return {
+    favorites: state.favorites,
+    toggleFavorite,
+  }
+}

--- a/packages/tui/src/db/context.tsx
+++ b/packages/tui/src/db/context.tsx
@@ -3,12 +3,14 @@ import type { Database } from "bun:sqlite"
 import { SettingsStore } from "./settings.js"
 import { RemoteServerStore } from "./servers.js"
 import { RemoteSkillStore } from "./skills.js"
+import { FavoritesStore } from "./favorites.js"
 
 export interface DbContext {
   db: Database
   settings: SettingsStore
   servers: RemoteServerStore
   skills: RemoteSkillStore
+  favorites: FavoritesStore
 }
 
 const DbCtx = createContext<DbContext | null>(null)
@@ -24,6 +26,7 @@ export function DbProvider({ db, children }: DbProviderProps) {
     settings: new SettingsStore(db),
     servers: new RemoteServerStore(db),
     skills: new RemoteSkillStore(db),
+    favorites: new FavoritesStore(db),
   }
 
   return <DbCtx.Provider value={ctx}>{children}</DbCtx.Provider>

--- a/packages/tui/src/db/favorites.ts
+++ b/packages/tui/src/db/favorites.ts
@@ -1,0 +1,39 @@
+import type { Database } from "bun:sqlite"
+
+export class FavoritesStore {
+  private db: Database
+
+  constructor(db: Database) {
+    this.db = db
+  }
+
+  list(): string[] {
+    const rows = this.db
+      .query("SELECT skill_name FROM favorites ORDER BY created_at DESC")
+      .all() as Array<{ skill_name: string }>
+    return rows.map((r) => r.skill_name)
+  }
+
+  has(name: string): boolean {
+    const row = this.db
+      .query("SELECT 1 FROM favorites WHERE skill_name = ?")
+      .get(name)
+    return row !== null
+  }
+
+  toggle(name: string): boolean {
+    if (this.has(name)) {
+      this.db.query("DELETE FROM favorites WHERE skill_name = ?").run(name)
+      return false
+    }
+    this.db.query("INSERT INTO favorites (skill_name) VALUES (?)").run(name)
+    return true
+  }
+
+  count(): number {
+    const row = this.db
+      .query("SELECT COUNT(*) as c FROM favorites")
+      .get() as { c: number }
+    return row.c
+  }
+}

--- a/packages/tui/src/db/migrations.ts
+++ b/packages/tui/src/db/migrations.ts
@@ -70,6 +70,17 @@ const MIGRATIONS: Migration[] = [
       INSERT OR IGNORE INTO schema_version VALUES (2);
     `,
   },
+  {
+    version: 3,
+    up: `
+      CREATE TABLE IF NOT EXISTS favorites (
+        skill_name TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      INSERT OR IGNORE INTO schema_version VALUES (3);
+    `,
+  },
 ]
 
 function getCurrentVersion(db: Database): number {

--- a/packages/tui/src/store/reducers.ts
+++ b/packages/tui/src/store/reducers.ts
@@ -10,6 +10,7 @@ export const initialState: AppState = {
   installedSkills: [],
   installedLoading: true,
   installedFilter: "",
+  favorites: [],
   searchQuery: "",
   searchResults: [],
   searchLoading: false,
@@ -60,6 +61,9 @@ export function appReducer(state: AppState, action: Action): AppState {
 
     case "SET_INSTALLED_FILTER":
       return { ...state, installedFilter: action.filter }
+
+    case "SET_FAVORITES":
+      return { ...state, favorites: action.favorites }
 
     case "SET_SEARCH_QUERY":
       return { ...state, searchQuery: action.query }

--- a/packages/tui/src/store/types.ts
+++ b/packages/tui/src/store/types.ts
@@ -63,10 +63,13 @@ export interface AppState {
   detectedAgents: DetectedAgent[]
 
   // Installed skills (home view)
-  selectedAgentFilter: string // agent name or "all"
+  selectedAgentFilter: string // agent name, "all", or "favorites"
   installedSkills: EnrichedSkill[]
   installedLoading: boolean
   installedFilter: string
+
+  // Favorites (skill names)
+  favorites: string[]
 
   // Search / discover
   searchQuery: string
@@ -98,6 +101,7 @@ export type Action =
   | { type: "SET_INSTALLED_SKILLS"; skills: EnrichedSkill[] }
   | { type: "SET_INSTALLED_LOADING"; loading: boolean }
   | { type: "SET_INSTALLED_FILTER"; filter: string }
+  | { type: "SET_FAVORITES"; favorites: string[] }
   | { type: "SET_SEARCH_QUERY"; query: string }
   | { type: "SET_SEARCH_RESULTS"; results: unknown[] }
   | { type: "SET_SEARCH_LOADING"; loading: boolean }

--- a/packages/tui/src/views/home.tsx
+++ b/packages/tui/src/views/home.tsx
@@ -73,8 +73,11 @@ export function HomeView() {
       skills = skills.filter((skill) => ids.has(skill.canonicalPath))
     }
 
-    // Agent filter
-    if (state.selectedAgentFilter !== "all") {
+    // Agent filter (or favorites)
+    if (state.selectedAgentFilter === "favorites") {
+      const favSet = new Set(state.favorites)
+      skills = skills.filter((s) => favSet.has(s.name))
+    } else if (state.selectedAgentFilter !== "all") {
       skills = skills.filter((s) =>
         s.agents.includes(state.selectedAgentFilter as any)
       )
@@ -96,7 +99,7 @@ export function HomeView() {
     }
 
     return skills
-  }, [state.installedSkills, state.selectedAgentFilter, state.installedFilter, selectedCollection, collections, collectionsVersion])
+  }, [state.installedSkills, state.selectedAgentFilter, state.installedFilter, state.favorites, selectedCollection, collections, collectionsVersion])
 
   useKeyboard((key) => {
     if (state.activeView !== "home") return
@@ -383,7 +386,7 @@ function DetailPanel({ skill, collections, selectedCollection }: DetailPanelProp
         <text>{" "}</text>
 
         {/* Shortcut hints */}
-        <text fg={colors.textDim}>v=view detail  d=remove  u=update  n=create skill  c=collections  Tab=switch pane</text>
+        <text fg={colors.textDim}>v=view detail  d=remove  u=update  f=favorite  n=create skill  c=collections  Tab=switch pane</text>
         <text fg={colors.border}>---</text>
 
         {/* SKILL.md content */}


### PR DESCRIPTION
## Summary

- Rebuilds the Favorites feature against the shared local SQLite DB (`~/.skillsgate/skillsgate.db`). The original server-side implementation was deleted in the backend-removal pivot, but the sidebar entry survived as dead UI — closes #10.
- **Desktop:** star button on every skill list row (always visible, dim when not favorited, amber when favorited), accurate sidebar count, working Favorites filter, dedicated empty state.
- **TUI:** Favorites row in the LIBRARY sidebar (j/k navigable), `f` shortcut toggles favorite on the selected skill, `★` indicator on favorited rows, filter wired through the existing `selectedAgentFilter` pipeline.
- Favorites are keyed by skill name so they survive uninstall/reinstall.
- Also includes a pre-existing CLI fallback-binary fix that was already on this branch.

## Version bumps

- `apps/desktop`: 0.5.0 → 0.5.1
- `packages/tui`: 0.2.1 → 0.2.2
- CLI: no bump (the CLI fix ships on next CLI release)

## Test plan

- [ ] Fresh DB: open desktop, verify migration v3 creates the `favorites` table without error
- [ ] Star a skill on the desktop — icon fills amber, sidebar count increments
- [ ] Click Favorites in sidebar — list filters; toggle a star to remove it; list updates
- [ ] Quit + relaunch — favorites persist
- [ ] TUI: press `j`/`k` in agents pane to reach the Favorites row; select it — list filters
- [ ] TUI: press `f` on a skill in the list — toast appears, `★` renders, count updates
- [ ] Empty state: clear all favorites with filter on — "No favorites yet…" message renders in both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)