### PR TITLE
Add tooltip for official skill badge

### DIFF
--- a/apps/desktop/src/renderer/app.css
+++ b/apps/desktop/src/renderer/app.css
@@ -120,6 +120,21 @@ body::before {
 	animation: slide-in-right 0.2s ease both;
 }
 
+.official-tooltip {
+	opacity: 0;
+	transform: translate(-50%, -2px);
+	transition:
+		opacity 120ms ease,
+		transform 120ms ease;
+	transition-delay: 0ms;
+}
+
+.official-badge:hover .official-tooltip {
+	opacity: 1;
+	transform: translate(-50%, 0);
+	transition-delay: 800ms;
+}
+
 /* ─── Markdown prose styles (skill detail page) ─── */
 .skill-prose {
 	line-height: 1.75;

--- a/apps/desktop/src/renderer/routes/discover.tsx
+++ b/apps/desktop/src/renderer/routes/discover.tsx
@@ -216,6 +216,20 @@ function BadgeCheckIcon({ size = 13 }: { size?: number }) {
   )
 }
 
+function OfficialBadge() {
+  return (
+    <span className="official-badge relative inline-flex flex-shrink-0 items-center">
+      <BadgeCheckIcon />
+      <span
+        role="tooltip"
+        className="official-tooltip pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-surface px-2 py-1 text-[10px] font-medium text-foreground shadow-lg"
+      >
+        Skill by a verified organization
+      </span>
+    </span>
+  )
+}
+
 function InstallsIcon() {
   return (
     <svg
@@ -263,7 +277,7 @@ const SkillCard = memo(function SkillCard({
         <h3 className="text-[13px] font-semibold text-foreground truncate">
           {skill.name}
         </h3>
-        {skill.isOfficial && <BadgeCheckIcon />}
+        {skill.isOfficial && <OfficialBadge />}
         {isInstalled && (
           <span className="text-[9px] uppercase tracking-wider font-medium text-accent bg-surface-hover px-1.5 py-0.5 rounded flex-shrink-0">
             installed


### PR DESCRIPTION
## Summary
- Add a delayed tooltip to the official skill badge in the desktop Discover grid.
- Keep the existing badge visual while explaining that it marks a skill by a verified organization.
- Show the tooltip after an 800ms hover delay.

## Test Plan
- [x] npm run build -w @skillsgate/desktop
- [x] npm run typecheck -w skillsgate --if-present
- [x] git diff --check
