### PR TITLE
fix(desktop): rebuild better-sqlite3 for Electron after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ packages/
 # Install dependencies
 npm install
 
+# Native desktop dependencies are rebuilt for Electron automatically.
+# If install scripts were skipped, run this before starting the desktop app:
+# npm run rebuild:native --workspace=@skillsgate/desktop
+
 # Web app (default workspace dev server)
 npm run dev
 
@@ -123,6 +127,11 @@ npm run deploy
 ```
 
 Requires Node.js 18+, Bun (for TUI development), and a Cloudflare account.
+
+The desktop app uses the native `better-sqlite3` module. A normal `npm install`
+rebuilds it for the Electron version pinned by the desktop workspace. If you
+install with `--ignore-scripts` or encounter a native module ABI mismatch, run
+`npm run rebuild:native --workspace=@skillsgate/desktop` manually.
 
 ## Contributing
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,7 +13,9 @@
     "package": "electron-vite build && electron-builder --config electron-builder.yml",
     "package:mac": "electron-vite build && electron-builder --config electron-builder.yml --mac",
     "package:win": "electron-vite build && electron-builder --config electron-builder.yml --win",
-    "package:linux": "electron-vite build && electron-builder --config electron-builder.yml --linux"
+    "package:linux": "electron-vite build && electron-builder --config electron-builder.yml --linux",
+    "postinstall": "npm run rebuild:native",
+    "rebuild:native": "electron-rebuild -f -w better-sqlite3"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
@@ -34,6 +36,7 @@
     "react-window": "^2.2.7"
   },
   "devDependencies": {
+    "@electron/rebuild": "4.0.3",
     "@tailwindcss/postcss": "4.2.2",
     "@types/better-sqlite3": "7.6.13",
     "@types/react": "19.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react-window": "^2.2.7"
       },
       "devDependencies": {
+        "@electron/rebuild": "4.0.3",
         "@tailwindcss/postcss": "4.2.2",
         "@types/better-sqlite3": "7.6.13",
         "@types/react": "19.2.13",


### PR DESCRIPTION
## Summary

Automatically rebuilds `better-sqlite3` for the Electron runtime after
installing desktop dependencies.

## Problem

A normal `npm install` can install or compile `better-sqlite3` for the
developer's regular Node.js ABI. The desktop application runs under Electron,
which may use a different ABI.

This causes `ERR_DLOPEN_FAILED`, prevents SQLite from loading, and breaks
database-dependent features such as trending skill discovery.

## Changes

- Add `@electron/rebuild` as a desktop development dependency.
- Add a desktop `postinstall` hook to rebuild `better-sqlite3`.
- Add a manual `rebuild:native` command.
- Document recovery for installations that skip lifecycle scripts.

## Testing

- Ran `npm run rebuild:native --workspace=@skillsgate/desktop`.
- Confirmed `electron-rebuild` completed successfully.
- Ran `npm run build --workspace=@skillsgate/desktop`.
- Confirmed the main, preload, and renderer production builds succeeded.
- Confirmed `better-sqlite3` loads under Electron 35.7.5 using ABI 133.
