### PR TITLE
fix(desktop): skip non-skill dirs in global scan, discover grouped skills

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -684,6 +684,55 @@ async function listInstalledSkillsInternal(
         }
 
         const skillMdPath = path.join(skillDir, "SKILL.md")
+
+        // A directory without a SKILL.md is not a skill, it is a grouping folder
+        // (e.g. ~/.claude/skills/<group>/<skill>/). This branch used to take it
+        // anyway and fall back to the folder name (parsed?.name || entry.name),
+        // which caused two problems:
+        //   1. a ghost entry in the list that always reports "this skill may not
+        //      have a SKILL.md file" on open -- it genuinely does not have one;
+        //   2. the real skills inside the group were never listed at all.
+        // The custom scan path branch (maybeCollectSkillDir) already skips
+        // directories without a SKILL.md, so align with it here, and descend one
+        // level so grouped skills are still discovered.
+        if (!(await fileExists(skillMdPath))) {
+          // Deliberately not annotated: Awaited<ReturnType<typeof fs.readdir>>
+          // resolves to the Buffer overload, which is exactly what the existing
+          // Dirent<NonSharedBuffer> errors in this file come from. Let TS infer.
+          let nested
+          try {
+            nested = await fs.readdir(skillDir, { withFileTypes: true })
+          } catch {
+            continue
+          }
+          for (const child of nested) {
+            if (!child.isDirectory() && !child.isSymbolicLink()) continue
+            const childDir = path.join(skillDir, child.name)
+            if (!(await fileExists(path.join(childDir, "SKILL.md")))) continue
+            const childParsed = await parseSkillMd(path.join(childDir, "SKILL.md"))
+            if (skillMap.has(childDir)) continue
+            const childLock = lock.skills[child.name]
+            skillMap.set(childDir, {
+              name: childParsed?.name || child.name,
+              description: childParsed?.description || "",
+              path: childDir,
+              canonicalPath: childDir,
+              agents: [agent.displayName],
+              agentShortCodes: [agent.shortCode],
+              scope: getScopeForPath(childDir),
+              projectName: null,
+              hasSupportingFiles: false,
+              supportingFiles: [],
+              source: childLock?.source,
+              sourceType: childLock?.sourceType,
+              installedAt: childLock?.installedAt,
+              updatedAt: childLock?.updatedAt,
+              folderName: child.name,
+            })
+          }
+          continue
+        }
+
         const parsed = await parseSkillMd(skillMdPath)
         const supportingFiles: SupportingFile[] = []
         const scope = getScopeForPath(skillDir)


### PR DESCRIPTION
Fixes #19.

## Problem

The two scan paths disagree on what counts as a skill.

`collectSkillsFromRoot` → `maybeCollectSkillDir` skips a directory with no `SKILL.md`:

```ts
const skillMdPath = path.join(skillDir, "SKILL.md")
if (!(await fileExists(skillMdPath))) return
```

The global-agent-directory branch in `listInstalledSkillsInternal` does not — it falls back to the folder name when parsing yields nothing:

```ts
const parsed = await parseSkillMd(skillMdPath)
const skillName = parsed?.name || entry.name   // no existence check
```

With the common grouped layout:

```
~/.claude/skills/
  my-group/                 ← listed as a "skill" (has no SKILL.md)
    actual-skill/
      SKILL.md              ← never shows up
```

1. `my-group` is listed; opening it reports "Skill content not available. This skill may not have a SKILL.md file." It genuinely does not have one, because it is not a skill.
2. `actual-skill` is never listed — the grouping folder shadows it.

## Fix

Align the global branch with the custom-root branch (no `SKILL.md` → not a skill), and descend one level so grouped skills are still discovered instead of that layout being silently dropped.

This is the shape suggested in #19; happy to drop the one-level descent and only skip non-skill directories if you would rather keep the change minimal.

## Verification

macOS (Apple Silicon), packaged build, against a real grouping directory under `~/.claude/skills`:

| | ghost entries | grouped skills visible |
|---|---|---|
| before | 2 | 0 |
| after | 0 | listed, content reads correctly |

`npx tsc -p apps/desktop/tsconfig.node.json --noEmit` reports 9 errors both on `main` and on this branch — no new type errors.

## Notes

The new code deliberately does not annotate the `readdir` result. `Awaited<ReturnType<typeof fs.readdir>>` resolves to the Buffer overload, which is where the pre-existing `Dirent<NonSharedBuffer>` errors in this file come from; letting TS infer avoids adding more of them.
