### PR TITLE
fix(desktop): keep custom scan path skills visible and readable

### DIFF
--- a/apps/desktop/src/main/db/skills-cache.ts
+++ b/apps/desktop/src/main/db/skills-cache.ts
@@ -98,7 +98,10 @@ export function loadCachedSkills(): InstalledSkillWithFolder[] {
  * Replace the entire cache with a fresh set of skills.
  * Uses a transaction for atomicity and speed (one disk sync instead of N).
  */
-export function saveCachedSkills(skills: InstalledSkillWithFolder[]): void {
+export function saveCachedSkills(
+  skills: InstalledSkillWithFolder[],
+  opts: { preserveCustomScope?: boolean } = {},
+): void {
   const db: Database.Database = openDb()
   const now = new Date().toISOString()
 
@@ -119,7 +122,15 @@ export function saveCachedSkills(skills: InstalledSkillWithFolder[]): void {
   `)
 
   const txn = db.transaction(() => {
-    db.prepare("DELETE FROM cached_skills").run()
+    // preserveCustomScope: a quick rescan (skipCustomPaths: true) never walks the
+    // custom scan paths. Deleting the whole table would then let a result set that
+    // does not contain them silently wipe them out -- which shows up as "I configured
+    // scan.customPaths but those skills are not in the list".
+    if (opts.preserveCustomScope) {
+      db.prepare("DELETE FROM cached_skills WHERE scope != 'custom'").run()
+    } else {
+      db.prepare("DELETE FROM cached_skills").run()
+    }
 
     for (const skill of skills) {
       insert.run(

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -421,11 +421,31 @@ function clearSupportingFilesCache(skillDir?: string): void {
 }
 
 function isSkillPathAllowed(resolvedPath: string): boolean {
-  return (
+  if (
     Object.values(agentRegistry).some((agent) =>
       resolvedPath.startsWith(path.resolve(agent.globalSkillsDir)),
-    ) || resolvedPath.startsWith(path.resolve(CANONICAL_SKILLS_DIR))
-  )
+    ) ||
+    resolvedPath.startsWith(path.resolve(CANONICAL_SKILLS_DIR))
+  ) {
+    return true
+  }
+
+  // Custom scan directories are allowed too. Without this the app contradicts
+  // itself: the scanner walks scan.customPaths and lists those skills, but reading
+  // one is denied because the allowlist does not know about that path -- the user
+  // sees "it is in the list, but opening it says the skill may have no SKILL.md".
+  // These directories are scan sources the user configured, so reading them is the
+  // expected behaviour.
+  try {
+    ensureStores()
+    const customScanPaths = settingsStore?.get<string[]>(CUSTOM_SCAN_PATHS_KEY, []) ?? []
+    return customScanPaths.some((custom) => {
+      const base = path.resolve(custom.replace(/^~(?=$|\/|\\)/, home))
+      return resolvedPath === base || resolvedPath.startsWith(base + path.sep)
+    })
+  } catch {
+    return false
+  }
 }
 
 function getExpandedTargetAgents(requestedAgentNames: string[]): AgentEntry[] {
@@ -790,10 +810,13 @@ function getCachedSkillsFingerprint(): string {
   return cachedSkillsFingerprint
 }
 
-function persistCachedSkills(raw: InternalSkill[]): string {
+function persistCachedSkills(
+  raw: InternalSkill[],
+  preserveCustomScope = false,
+): string {
   const fingerprint = createSkillsFingerprint(raw)
   if (fingerprint !== getCachedSkillsFingerprint()) {
-    saveCachedSkills(raw)
+    saveCachedSkills(raw, { preserveCustomScope })
     cachedSkillsFingerprint = fingerprint
   }
   return fingerprint
@@ -818,6 +841,7 @@ async function runRescan(
   key: string,
   run: () => Promise<InternalSkill[]>,
   broadcast: boolean,
+  preserveCustomScope = false,
 ): Promise<Array<Omit<InternalSkill, "folderName">>> {
   const inFlight = rescanInFlight.get(key)
   if (inFlight) {
@@ -825,9 +849,22 @@ async function runRescan(
   }
 
   const task = (async () => {
-    const raw = await run()
+    let raw = await run()
+    // A quick rescan skips the custom paths. Persisting and broadcasting that result
+    // as-is drops the custom-path skills from both the cache and the UI. Merge the
+    // custom entries already in the cache back in first, so the cache, the broadcast
+    // and the return value all stay consistent.
+    if (preserveCustomScope) {
+      const preserved = loadCachedSkills().filter((s) => s.scope === "custom")
+      if (preserved.length > 0) {
+        const seen = new Set(raw.map((s) => s.canonicalPath))
+        raw = raw.concat(
+          (preserved as InternalSkill[]).filter((s) => !seen.has(s.canonicalPath)),
+        )
+      }
+    }
     clearSupportingFilesCache()
-    const fingerprint = persistCachedSkills(raw)
+    const fingerprint = persistCachedSkills(raw, preserveCustomScope)
     maybeBroadcastSkills(raw, fingerprint, broadcast)
     return toRendererSkills(raw)
   })().finally(() => {
@@ -874,6 +911,8 @@ async function rescanAndCache(
       })
     },
     opts.broadcast ?? true,
+    // This pass did not scan the custom paths -> keep the cached custom entries.
+    opts.skipCustomPaths === true,
   )
 }
 


### PR DESCRIPTION
Fixes #17. Fixes #18.

Two related defects, both in how custom scan paths (`scan.customPaths`) are treated. They are separate root causes but they hit the same feature, so they are in one PR — happy to split if you prefer.

## Bug 1 — skills appear once, then disappear (#17)

`skills:list-installed` kicks off a background quick rescan (`skipCustomPaths: true`) whenever the cache is non-empty, and `saveCachedSkills` clears the whole table before writing:

```ts
db.prepare("DELETE FROM cached_skills").run()
```

A result set that does not include the custom paths therefore wipes those rows. The file watcher runs the same quick path on every file change, so it happens repeatedly.

**Fix:** `saveCachedSkills` takes `preserveCustomScope` and deletes with `WHERE scope != 'custom'`.

Fixing only the cache is not enough — the payload broadcast to the renderer is still the quick-scan result, so the list is emptied anyway. `runRescan` now merges the existing custom entries back into the result, keeping cache, broadcast and return value consistent.

## Bug 2 — skill is listed, opening it says "no SKILL.md" (#18)

`isSkillPathAllowed()` only allows each agent's `globalSkillsDir` and `CANONICAL_SKILLS_DIR`, never `scan.customPaths`. Scanning and reading use two different path rules, so the app contradicts itself: the scanner lists the skill, the read guard denies it.

**Fix:** allow the configured custom scan directories as well. They are scan sources the user set up, so reading them is the expected behaviour. Paths are resolved (with `~` expansion) and matched on a path-separator boundary, so `/foo/bar-evil` does not match a configured `/foo/bar`.

## Verification

macOS (Apple Silicon), packaged build, driving the renderer over the Electron remote debugging port (not simulated clicks):

- skill count 73 → 64 (62 custom + 2 global)
- opening a custom-path skill renders the full `SKILL.md`; "skill content not available" is gone
- switching tabs 3 times keeps `custom=62` stable — bug 1 regression check
- `npx tsc -p apps/desktop/tsconfig.node.json --noEmit`: 9 errors both on `main` and on this branch, no new type errors
