### PR TITLE
feat(desktop): locale registry, resolver and language selector

### DIFF
--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,3 +1,4 @@
+import { t, useLocale } from "./lib/i18n"
 import { Suspense, lazy } from "react"
 import { HashRouter, Routes, Route } from "react-router-dom"
 import { Sidebar } from "./components/sidebar"
@@ -27,15 +28,23 @@ const ScanSources = lazy(() =>
 function RouteFallback() {
   return (
     <div className="flex flex-1 items-center justify-center text-[12px] text-muted">
-      Loading view...
+      {t("Loading view...")}
     </div>
   )
 }
 
 export function App() {
+  const locale = useLocale()
+
   return (
     <HashRouter>
-      <div className="flex h-screen overflow-hidden bg-background text-foreground font-sans">
+      {/* Keyed on the locale: t() is a plain function, so re-keying the tree is
+          what makes a language switch reach memoised components immediately,
+          without reloading the window. */}
+      <div
+        key={locale}
+        className="flex h-screen overflow-hidden bg-background text-foreground font-sans"
+      >
         <Sidebar />
         <main className="flex-1 min-w-0 flex flex-col overflow-hidden">
           <UpdateBanner />

--- a/apps/desktop/src/renderer/components/manage-popover.tsx
+++ b/apps/desktop/src/renderer/components/manage-popover.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 // apps/desktop/src/renderer/components/manage-popover.tsx
 import { useEffect, useRef } from "react"
 
@@ -75,10 +76,10 @@ export function ManagePopover({
         <span className="text-foreground text-base leading-none mt-0.5">↻</span>
         <span className="flex-1">
           <span className="block text-[12px] font-medium text-foreground">
-            Refresh from remote
+            {t("Refresh from remote")}
           </span>
           <span className="block text-[11px] text-muted mt-0.5">
-            Pull the latest list of skills on this server.
+            {t("Pull the latest list of skills on this server.")}
           </span>
         </span>
       </button>
@@ -94,7 +95,7 @@ export function ManagePopover({
         <span className="text-foreground text-base leading-none mt-0.5">↑</span>
         <span className="flex-1">
           <span className="block text-[12px] font-medium text-foreground">
-            Push to remote
+            {t("Push to remote")}
           </span>
           <span className="block text-[11px] text-muted mt-0.5">
             Send your local skills. Adds new ones, updates changed ones, never deletes.
@@ -114,7 +115,7 @@ export function ManagePopover({
         <span className="flex-1">
           <span className="flex items-center gap-2">
             <span className="text-[12px] font-medium text-foreground">
-              Mirror to remote
+              {t("Mirror to remote")}
             </span>
             <span className="px-1.5 py-0.5 text-[10px] rounded bg-red-500/15 text-red-400">
               destructive

--- a/apps/desktop/src/renderer/components/sidebar.tsx
+++ b/apps/desktop/src/renderer/components/sidebar.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import { NavLink, useLocation } from "react-router-dom"
 import { useEffect, useMemo, useState } from "react"
 import { ThemeToggle } from "@skillsgate/ui"
@@ -5,6 +6,7 @@ import { electronAPI } from "../lib/electron-api"
 
 interface NavItem {
   to: string
+  /** English source string, translated at render time — see `lib/i18n`. */
   label: string
   icon: React.ReactNode
   badge?: number
@@ -98,7 +100,7 @@ function CompactNavButton({ to, label, icon, badge }: NavItem) {
     <NavLink
       to={to}
       end={to === "/"}
-      title={label}
+      title={t(label)}
       className={({ isActive }) =>
         `relative flex items-center justify-center w-9 h-9 rounded-lg transition-colors ${
           isActive
@@ -132,7 +134,7 @@ function FullNavButton({ to, label, icon, badge }: NavItem) {
       }
     >
       {icon}
-      <span className="flex-1">{label}</span>
+      <span className="flex-1">{t(label)}</span>
       {badge !== undefined && badge > 0 && (
         <span className="text-[10px] font-mono text-muted">
           {badge}
@@ -191,7 +193,7 @@ export function Sidebar() {
         <div className="mt-auto pb-3 flex flex-col items-center gap-1 px-1.5">
           <NavLink
             to="/settings"
-            title="Settings"
+            title={t("Settings")}
             className={({ isActive }) =>
               `flex items-center justify-center w-9 h-9 rounded-lg transition-colors ${
                 isActive
@@ -278,10 +280,10 @@ export function Sidebar() {
             <circle cx="12" cy="12" r="3" />
             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
-          Settings
+          {t("Settings")}
         </NavLink>
         <div className="flex items-center justify-between px-3 py-1">
-          <span className="text-xs text-muted">Theme</span>
+          <span className="text-xs text-muted">{t("Theme")}</span>
           <ThemeToggle />
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/update-banner.tsx
+++ b/apps/desktop/src/renderer/components/update-banner.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import { useState, useEffect } from "react"
 import { electronAPI } from "../lib/electron-api"
 
@@ -23,20 +24,20 @@ export function UpdateBanner() {
     return (
       <div className="flex items-center justify-between px-4 py-2.5 bg-accent/10 border-b border-accent/20 text-[12px]">
         <span className="text-foreground">
-          Update <strong>v{state.downloadedVersion}</strong> is ready to install.
+          {t("Update")} <strong>v{state.downloadedVersion}</strong> is ready to install.
         </span>
         <div className="flex items-center gap-2">
           <button
             onClick={() => setDismissed(true)}
             className="text-muted hover:text-foreground transition-colors px-2 py-1"
           >
-            Later
+            {t("Later")}
           </button>
           <button
             onClick={() => electronAPI.updatesInstall()}
             className="bg-foreground text-background px-3 py-1 rounded-md hover:opacity-90 transition-opacity font-medium"
           >
-            Restart & Update
+            {t("Restart & Update")}
           </button>
         </div>
       </div>
@@ -47,7 +48,7 @@ export function UpdateBanner() {
     return (
       <div className="flex items-center justify-between px-4 py-2.5 bg-accent/10 border-b border-accent/20 text-[12px]">
         <span className="text-foreground">
-          Downloading update <strong>v{state.availableVersion}</strong>...
+          {t("Downloading update")} <strong>v{state.availableVersion}</strong>...
           {state.progressPercent != null && (
             <span className="text-muted ml-2">{Math.round(state.progressPercent)}%</span>
           )}
@@ -56,7 +57,7 @@ export function UpdateBanner() {
           onClick={() => setDismissed(true)}
           className="text-muted hover:text-foreground transition-colors px-2 py-1"
         >
-          Dismiss
+          {t("Dismiss")}
         </button>
       </div>
     )
@@ -66,7 +67,7 @@ export function UpdateBanner() {
     return (
       <div className="flex items-center justify-between px-4 py-2.5 bg-accent/10 border-b border-accent/20 text-[12px]">
         <span className="text-foreground">
-          Downloading update <strong>v{state.availableVersion}</strong>...
+          {t("Downloading update")} <strong>v{state.availableVersion}</strong>...
           {state.progressPercent != null && (
             <span className="text-muted ml-2">{Math.round(state.progressPercent)}%</span>
           )}
@@ -75,7 +76,7 @@ export function UpdateBanner() {
           onClick={() => setDismissed(true)}
           className="text-muted hover:text-foreground transition-colors px-2 py-1"
         >
-          Dismiss
+          {t("Dismiss")}
         </button>
       </div>
     )

--- a/apps/desktop/src/renderer/lib/i18n.ts
+++ b/apps/desktop/src/renderer/lib/i18n.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimal i18n layer.
+ *
+ * Design notes (read before "optimising" them away):
+ *  1. **Keys are the English source string**, not a separate key namespace.
+ *     If an upstream string changes and a dictionary is not updated, that entry
+ *     simply falls back to English — nothing breaks, and nothing points at a
+ *     missing key. It also means a partial translation is shippable.
+ *  2. **No external dependency and no new IPC surface.** The saved preference
+ *     rides the existing settings channel; `package.json` and the lockfile are
+ *     untouched, so there is no dependency tree to reconcile on rebase.
+ *  3. Brand and agent names (SkillsGate, Cursor, GitHub Copilot, ...) are
+ *     deliberately left out of dictionaries and fall through to English.
+ */
+
+import { useSyncExternalStore } from "react"
+import {
+  DEFAULT_LOCALE,
+  LOCALES,
+  dictFor,
+  isSupportedLocale,
+  type Locale,
+} from "../locales"
+import { electronAPI } from "./electron-api"
+
+export type { Locale }
+export { LOCALES }
+
+/** Settings key holding the user's explicit choice. Absent = follow the system. */
+const SETTINGS_KEY = "ui.locale"
+
+let current: Locale = DEFAULT_LOCALE
+let dict: Record<string, string> = dictFor(DEFAULT_LOCALE)
+
+const listeners = new Set<() => void>()
+
+/**
+ * Resolution order: saved preference → system locale (exact match such as
+ * `pt-BR`, then base language `pt`) → English.
+ */
+export function resolveLocale(
+  saved: unknown,
+  systemLocale: string | undefined,
+): Locale {
+  if (isSupportedLocale(saved)) return saved
+
+  if (systemLocale) {
+    if (isSupportedLocale(systemLocale)) return systemLocale
+    const base = systemLocale.split("-")[0]
+    const match = LOCALES.find((entry) => entry.code.split("-")[0] === base)
+    if (match) return match.code
+  }
+
+  return DEFAULT_LOCALE
+}
+
+export function getLocale(): Locale {
+  return current
+}
+
+export function setLocale(locale: Locale): void {
+  if (locale === current) return
+  current = locale
+  dict = dictFor(locale)
+  for (const listener of listeners) listener()
+}
+
+/**
+ * Resolves the startup locale. Call and await this before the first render so
+ * the UI never flashes English before switching.
+ */
+export async function initLocale(): Promise<Locale> {
+  let saved: unknown = null
+  try {
+    saved = await electronAPI.settingsGet<unknown>(SETTINGS_KEY, null)
+  } catch {
+    // Settings unavailable — fall through to the system locale.
+  }
+  setLocale(resolveLocale(saved, navigator.language))
+  return current
+}
+
+/** Applies the choice immediately, then persists it. */
+export async function changeLocale(locale: Locale): Promise<void> {
+  setLocale(locale)
+  try {
+    await electronAPI.settingsSet(SETTINGS_KEY, locale)
+  } catch (err) {
+    console.error("Failed to persist locale:", err)
+  }
+}
+
+/** Look up a translation. Falls back to the key, i.e. the English source string. */
+export function t(key: string): string {
+  return dict[key] ?? key
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Subscribes a component to locale changes.
+ *
+ * Used at the app root to key the tree on the current locale: `t()` is a plain
+ * function, so `memo`ised components (there are several) would otherwise keep
+ * rendering the previous language until their props happened to change.
+ */
+export function useLocale(): Locale {
+  return useSyncExternalStore(subscribe, getLocale, getLocale)
+}

--- a/apps/desktop/src/renderer/locales/index.ts
+++ b/apps/desktop/src/renderer/locales/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Locale registry — the single extension point for adding a language.
+ *
+ * To add one:
+ *   1. Create `./<code>.ts` exporting a `Record<string, string>` dictionary.
+ *   2. Add one entry to `LOCALES` below.
+ *
+ * Nothing else changes. The settings selector, the locale resolver and any
+ * future tooling all enumerate languages from this list, so contributors never
+ * touch `lib/i18n.ts` or any component.
+ *
+ * `label` is the language's endonym (`简体中文`, not "Chinese") — that is what
+ * people scan for in a language menu.
+ */
+
+import { zhCN } from "./zh-CN"
+
+type Dict = Record<string, string>
+
+/**
+ * English carries an empty dictionary by design: translation keys *are* the
+ * English source strings, so every lookup falls through to the key itself.
+ * English is therefore always 100% complete and needs no maintenance.
+ */
+export const LOCALES = [
+  { code: "en", label: "English", dict: {} as Dict },
+  { code: "zh-CN", label: "简体中文", dict: zhCN },
+] as const satisfies ReadonlyArray<{ code: string; label: string; dict: Dict }>
+
+/** Derived from the registry, so adding a language does not touch this type. */
+export type Locale = (typeof LOCALES)[number]["code"]
+
+export const DEFAULT_LOCALE: Locale = "en"
+
+export function isSupportedLocale(value: unknown): value is Locale {
+  return LOCALES.some((entry) => entry.code === value)
+}
+
+export function dictFor(locale: Locale): Dict {
+  return LOCALES.find((entry) => entry.code === locale)?.dict ?? {}
+}

--- a/apps/desktop/src/renderer/locales/zh-CN.ts
+++ b/apps/desktop/src/renderer/locales/zh-CN.ts
@@ -1,0 +1,164 @@
+/**
+ * Simplified Chinese dictionary.
+ *
+ * Keys are the English source strings, so adding an entry means copying the
+ * literal UI text as the key. Anything not listed here falls back to English —
+ * brand and agent names (SkillsGate, Cursor, GitHub Copilot, Droid CLI, ...)
+ * are deliberately left out so they render untranslated.
+ */
+
+export const zhCN: Record<string, string> = {
+  // Navigation and tabs
+  Installed: "已安装",
+  Discover: "发现",
+  Favorites: "收藏",
+  Servers: "服务器",
+  Settings: "设置",
+  Library: "技能库",
+  "Local Library": "本地技能库",
+  "All Skills": "全部技能",
+  "Remote Servers": "远程服务器",
+  Collections: "合集",
+  Collection: "合集",
+  Tools: "工具",
+  Targets: "安装目标",
+  About: "关于",
+  Privacy: "隐私",
+  Telemetry: "遥测",
+  Updates: "更新",
+  Update: "更新",
+  Theme: "主题",
+  GitHub: "GitHub",
+
+  // Common actions
+  Add: "添加",
+  Cancel: "取消",
+  Create: "新建",
+  Delete: "删除",
+  Done: "完成",
+  Edit: "编辑",
+  Install: "安装",
+  Later: "稍后",
+  Preview: "预览",
+  Remove: "移除",
+  Saved: "已保存",
+  Search: "搜索",
+  View: "查看",
+  Browse: "浏览",
+  Dismiss: "关闭",
+  "Add Root": "添加根目录",
+  "Add Server": "添加服务器",
+  "New Skill": "新建技能",
+  "Remove all": "全部移除",
+  "Remove from all": "从所有目标移除",
+  "Remove selected": "移除所选",
+  "Remove skill": "移除技能",
+  "Delete server": "删除服务器",
+  "Delete collection": "删除合集",
+  "Rename collection": "重命名合集",
+  "Create collection": "新建合集",
+  "Edit server": "编辑服务器",
+  "Manage this server": "管理此服务器",
+  "Test connection": "测试连接",
+  "Show in Finder": "在访达中显示",
+  "Clear filters": "清除筛选",
+  "Browse skills": "浏览技能",
+  "Add your first server": "添加第一台服务器",
+  "Back to Servers": "返回服务器列表",
+
+  // Sync and push
+  "Push to remote": "推送到远程",
+  "Mirror to remote": "镜像到远程",
+  "Refresh from remote": "从远程刷新",
+  "Mirror installs to additional targets": "把安装镜像到其他目标",
+  "Sync Rules": "同步规则",
+  "Pull the latest list of skills on this server.": "拉取此服务器上最新的技能列表。",
+  "Try syncing the server to discover skills.": "试试同步该服务器来发现技能。",
+
+  // Loading states
+  "Installing...": "安装中…",
+  "Loading catalog...": "正在加载目录…",
+  "Loading content...": "正在加载内容…",
+  "Loading popular skills...": "正在加载热门技能…",
+  "Loading servers...": "正在加载服务器…",
+  "Loading skills...": "正在加载技能…",
+  "Loading view...": "正在加载视图…",
+  "Scanning for installed skills...": "正在扫描已安装的技能…",
+  "Downloading update": "正在下载更新",
+  "Restart & Update": "重启并更新",
+  "Restart to install": "重启以完成安装",
+
+  // Empty states
+  "No collections yet.": "还没有合集。",
+  "No custom scan paths configured.": "尚未配置自定义扫描路径。",
+  "No favorites yet.": "还没有收藏。",
+  "No more results": "没有更多结果",
+  "No servers configured.": "尚未配置服务器。",
+  "No skills found on this server.": "此服务器上没有找到技能。",
+  "No skills installed yet.": "还没有安装任何技能。",
+  "No skills match your search.": "没有技能匹配你的搜索。",
+  "None configured": "未配置",
+  "None yet": "暂无",
+  "Head to Discover to find skills.": "去「发现」页找技能。",
+  "Click the star on any skill to save it here.": "点击技能上的星标即可收藏到这里。",
+  "Select a skill to view details": "选择一个技能查看详情",
+  "Skill content not available.": "技能内容不可用。",
+  "Skill content not available. This skill may not have a SKILL.md file.":
+    "技能内容不可用。该技能可能没有 SKILL.md 文件。",
+  "Skill content not cached. Sync the server to fetch content.":
+    "技能内容未缓存。同步该服务器以获取内容。",
+
+  // Forms and fields
+  Host: "主机",
+  Port: "端口",
+  Username: "用户名",
+  Label: "标签",
+  Installation: "安装",
+  "Install method": "安装方式",
+  "Install targets": "安装目标",
+  "Default Targets": "默认目标",
+  "Default scope": "默认范围",
+  "Search preference": "搜索偏好",
+  "Skill name": "技能名称",
+  "Short description": "简短描述",
+  "Collection name": "合集名称",
+  "SSH Key Path": "SSH 私钥路径",
+  "Skills Base Path": "技能根路径",
+  "Scan Paths": "扫描路径",
+  "Scan Sources": "扫描来源",
+  "Custom Roots": "自定义根目录",
+  "Custom scan directories": "自定义扫描目录",
+  "Supporting Files": "附属文件",
+  "Current Coverage": "当前覆盖范围",
+  "Desktop app updates": "桌面应用更新",
+  "Official only": "仅官方",
+  Official: "官方",
+  "Search skills...": "搜索技能…",
+  "Search by name or keyword... (Enter to search)": "按名称或关键词搜索…（回车搜索）",
+  "Auto-discover (id_ed25519, id_rsa, ...)": "自动探测（id_ed25519、id_rsa 等）",
+
+  // Descriptions and help text
+  "Manage AI agent skills from your desktop.": "在桌面端统一管理 AI agent 技能。",
+  "Configure your SkillsGate Desktop preferences.": "配置 SkillsGate 桌面端偏好设置。",
+  "Configure an SSH connection to discover remote skills.": "配置 SSH 连接以发现远程技能。",
+  "Connect to remote machines via SSH to discover and sync skills.":
+    "通过 SSH 连接远程机器，发现并同步技能。",
+  "Add a server to discover skills from remote machines.": "添加服务器，从远程机器发现技能。",
+  "Add and remove folders to include in local skill discovery.":
+    "增删纳入本地技能发现的文件夹。",
+  "Bring Your Own Skill Folders": "接入你自己的技能目录",
+  "Create a local skill and install it into one or more targets.":
+    "新建一个本地技能，并安装到一个或多个目标。",
+  "Global installs still scanned automatically": "全局安装仍会自动扫描",
+  "Project-local paths discovered under each root": "在每个根目录下发现的项目级路径",
+  "Skill by a verified organization": "由已验证组织发布的技能",
+
+  // Language
+  Language: "语言",
+  "Display language": "界面语言",
+  "Applies immediately. Untranslated text stays in English.":
+    "立即生效。未翻译的文本将显示英文。",
+
+  // Status messages
+  "Save failed": "保存失败",
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,8 +1,12 @@
 import { createRoot } from "react-dom/client"
 import { App } from "./app"
+import { initLocale } from "./lib/i18n"
 import "./app.css"
 
 const root = document.getElementById("root")
 if (!root) throw new Error("Root element not found")
 
-createRoot(root).render(<App />)
+// Resolve the locale before the first paint so the UI never flashes English.
+initLocale().finally(() => {
+  createRoot(root).render(<App />)
+})

--- a/apps/desktop/src/renderer/routes/discover.tsx
+++ b/apps/desktop/src/renderer/routes/discover.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import {
   memo,
   useDeferredValue,
@@ -208,7 +209,7 @@ function BadgeCheckIcon({ size = 13 }: { size?: number }) {
       strokeLinecap="round"
       strokeLinejoin="round"
       className="text-blue-500 flex-shrink-0"
-      aria-label="Official"
+      aria-label={t("Official")}
     >
       <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" />
       <path d="m9 12 2 2 4-4" />
@@ -224,7 +225,7 @@ function OfficialBadge() {
         role="tooltip"
         className="official-tooltip pointer-events-none absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-surface px-2 py-1 text-[10px] font-medium text-foreground shadow-lg"
       >
-        Skill by a verified organization
+        {t("Skill by a verified organization")}
       </span>
     </span>
   )
@@ -342,7 +343,7 @@ function AgentDropdown({
   return (
     <div ref={ref} className="relative">
       <p className="text-[12px] font-medium text-foreground mb-2">
-        Install targets
+        {t("Install targets")}
       </p>
       <button
         type="button"
@@ -560,7 +561,7 @@ function DetailPanel({
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 text-[11px] text-muted hover:text-foreground transition-colors"
           >
-            GitHub <ExternalLinkIcon />
+            {t("GitHub")} <ExternalLinkIcon />
           </a>
         </div>
 
@@ -583,7 +584,7 @@ function DetailPanel({
             <div className="flex items-center gap-3 mb-4">
               {installed ? (
                 <span className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-[12px] font-medium bg-surface-hover text-muted border border-border">
-                  <CheckIcon /> Installed
+                  <CheckIcon /> {t("Installed")}
                 </span>
               ) : (
                 <button
@@ -593,11 +594,11 @@ function DetailPanel({
                 >
                   {installing ? (
                     <>
-                      <SpinnerIcon /> Installing...
+                      <SpinnerIcon /> {t("Installing...")}
                     </>
                   ) : (
                     <>
-                      <DownloadIcon /> Install
+                      <DownloadIcon /> {t("Install")}
                     </>
                   )}
                 </button>
@@ -636,7 +637,7 @@ function DetailPanel({
             />
           ) : (
             <p className="text-sm text-muted">
-              Skill content not available.
+              {t("Skill content not available.")}
             </p>
           )}
         </div>
@@ -857,7 +858,7 @@ export function Discover() {
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="px-8 pt-6 pb-4">
-        <h2 className="text-xl font-bold text-foreground mb-1">Discover</h2>
+        <h2 className="text-xl font-bold text-foreground mb-1">{t("Discover")}</h2>
         <p className="text-[12px] text-muted mb-5">
           Browse and search skills from skills.sh.{" "}
           {skills.length > 0 && (
@@ -871,7 +872,7 @@ export function Discover() {
           </div>
           <input
             type="text"
-            placeholder="Search by name or keyword... (Enter to search)"
+            placeholder={t("Search by name or keyword... (Enter to search)")}
             value={searchQuery}
             onChange={(e) => handleSearchChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") handleSearchSubmit() }}
@@ -923,7 +924,7 @@ export function Discover() {
               onChange={(e) => setOfficialOnly(e.target.checked)}
               className="h-3 w-3 accent-blue-500"
             />
-            Official only
+            {t("Official only")}
           </label>
         </div>
       </div>
@@ -942,7 +943,7 @@ export function Discover() {
             <div className="text-center">
               <SpinnerIcon />
               <p className="text-muted text-[12px] mt-3">
-                Loading popular skills...
+                {t("Loading popular skills...")}
               </p>
             </div>
           </div>
@@ -951,7 +952,7 @@ export function Discover() {
             <div className="text-center">
               <SpinnerIcon />
               <p className="text-muted text-[12px] mt-3">
-                Loading catalog...
+                {t("Loading catalog...")}
               </p>
             </div>
           </div>
@@ -994,7 +995,7 @@ export function Discover() {
             )}
             {isSearching && !hasMore && visibleSkills.length > 0 && (
               <p className="text-center text-[11px] text-muted py-4">
-                No more results
+                {t("No more results")}
               </p>
             )}
           </>

--- a/apps/desktop/src/renderer/routes/home.tsx
+++ b/apps/desktop/src/renderer/routes/home.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import {
   useDeferredValue,
   useEffect,
@@ -210,7 +211,7 @@ function LeftSidebar({
       {/* Library section */}
       <div className="px-3 pt-4 pb-2">
         <h3 className="text-[10px] uppercase tracking-widest font-semibold text-muted mb-2 px-2">
-          Library
+          {t("Library")}
         </h3>
         <nav className="flex flex-col gap-0.5">
           <button
@@ -224,7 +225,7 @@ function LeftSidebar({
                 : "text-muted hover:text-foreground hover:bg-surface-hover"
             }`}
           >
-            <span>All Skills</span>
+            <span>{t("All Skills")}</span>
             <span
               className={`text-[10px] font-mono ${
                 activeFilter === "all" && selectedAgent === null
@@ -243,7 +244,7 @@ function LeftSidebar({
                 : "text-muted hover:text-foreground hover:bg-surface-hover"
             }`}
           >
-            <span>Favorites</span>
+            <span>{t("Favorites")}</span>
             <span
               className={`text-[10px] font-mono ${
                 activeFilter === "favorites" ? "text-foreground" : "text-muted"
@@ -259,7 +260,7 @@ function LeftSidebar({
       {agentsWithSkills.length > 0 && (
         <div className="px-3 pt-3 pb-2">
           <h3 className="text-[10px] uppercase tracking-widest font-semibold text-muted mb-2 px-2">
-            Tools
+            {t("Tools")}
           </h3>
           <nav className="flex flex-col gap-0.5">
             {agentsWithSkills.map((agent) => (
@@ -314,19 +315,19 @@ function LeftSidebar({
       <div className="px-3 pt-3 pb-2">
         <div className="flex items-center justify-between px-2 mb-2">
           <h3 className="text-[10px] uppercase tracking-widest font-semibold text-muted">
-            Collections
+            {t("Collections")}
           </h3>
           <button
             onClick={onCreateCollection}
             className="text-[11px] text-muted hover:text-foreground"
-            title="Create collection"
+            title={t("Create collection")}
           >
             +
           </button>
         </div>
         <nav className="flex flex-col gap-0.5">
           {Object.keys(collections).length === 0 ? (
-            <p className="text-[11px] text-muted px-2 italic">None yet</p>
+            <p className="text-[11px] text-muted px-2 italic">{t("None yet")}</p>
           ) : (
             Object.keys(collections)
               .sort()
@@ -365,14 +366,14 @@ function LeftSidebar({
                   <button
                     onClick={() => onRenameCollection(name)}
                     className="hidden group-hover:inline text-[10px] text-muted hover:text-foreground"
-                    title="Rename collection"
+                    title={t("Rename collection")}
                   >
                     ✎
                   </button>
                   <button
                     onClick={() => onDeleteCollection(name)}
                     className="hidden group-hover:inline text-[10px] text-muted hover:text-red-400"
-                    title="Delete collection"
+                    title={t("Delete collection")}
                   >
                     ×
                   </button>
@@ -383,9 +384,9 @@ function LeftSidebar({
       </div>
       <div className="px-3 pt-3 pb-4 mt-auto">
         <h3 className="text-[10px] uppercase tracking-widest font-semibold text-muted mb-2 px-2">
-          Servers
+          {t("Servers")}
         </h3>
-        <p className="text-[11px] text-muted px-2 italic">None configured</p>
+        <p className="text-[11px] text-muted px-2 italic">{t("None configured")}</p>
       </div>
     </aside>
   )
@@ -622,12 +623,12 @@ function MiddlePanel({
       {/* Search input */}
       <div className="p-3 border-b border-border">
         <div className="mb-2 flex items-center justify-between">
-          <p className="text-[10px] uppercase tracking-widest text-muted">Local Library</p>
+          <p className="text-[10px] uppercase tracking-widest text-muted">{t("Local Library")}</p>
           <button
             onClick={onCreateSkill}
             className="rounded-md border border-border px-2 py-1 text-[11px] text-foreground hover:bg-surface-hover"
           >
-            New Skill
+            {t("New Skill")}
           </button>
         </div>
         <div className="relative">
@@ -636,7 +637,7 @@ function MiddlePanel({
           </div>
           <input
             type="text"
-            placeholder="Search skills..."
+            placeholder={t("Search skills...")}
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             className="w-full pl-8 pr-8 py-1.5 rounded-md bg-surface border border-border text-[12px] text-foreground placeholder:text-muted focus:outline-none focus:border-accent transition-colors"
@@ -686,7 +687,7 @@ function MiddlePanel({
         {loading ? (
           <div className="flex items-center justify-center py-12">
             <p className="text-[12px] text-muted animate-fade-in">
-              Scanning for installed skills...
+              {t("Scanning for installed skills...")}
             </p>
           </div>
         ) : filteredSkills.length === 0 ? (
@@ -695,29 +696,29 @@ function MiddlePanel({
               <>
                 <SkillsGateIcon />
                 <p className="text-muted text-[12px] mt-3">
-                  No skills installed yet.
+                  {t("No skills installed yet.")}
                 </p>
                 <p className="text-muted text-[11px] mt-1">
-                  Head to Discover to find skills.
+                  {t("Head to Discover to find skills.")}
                 </p>
               </>
             ) : activeFilter === "favorites" ? (
               <>
-                <p className="text-muted text-[12px]">No favorites yet.</p>
+                <p className="text-muted text-[12px]">{t("No favorites yet.")}</p>
                 <p className="text-muted text-[11px] mt-1">
-                  Click the star on any skill to save it here.
+                  {t("Click the star on any skill to save it here.")}
                 </p>
               </>
             ) : (
               <>
                 <p className="text-muted text-[12px]">
-                  No skills match your search.
+                  {t("No skills match your search.")}
                 </p>
                 <button
                   onClick={onClearFilters}
                   className="text-accent text-[11px] mt-2 hover:text-foreground transition-colors"
                 >
-                  Clear filters
+                  {t("Clear filters")}
                 </button>
               </>
             )}
@@ -747,7 +748,7 @@ function MiddlePanel({
                 onClick={() => setShowCollectionDropdown(!showCollectionDropdown)}
                 className="rounded-md border border-border px-2 py-1 text-[11px] text-foreground hover:bg-surface-hover transition-colors flex items-center gap-1"
               >
-                <span>Collection</span>
+                <span>{t("Collection")}</span>
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="6 9 12 15 18 9" />
                 </svg>
@@ -788,14 +789,14 @@ function MiddlePanel({
               onClick={onBulkDelete}
               className="rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[11px] text-red-400 hover:bg-red-500/20 transition-colors"
             >
-              Delete
+              {t("Delete")}
             </button>
             {/* Cancel */}
             <button
               onClick={onMultiSelectClear}
               className="rounded-md px-2 py-1 text-[11px] text-muted hover:text-foreground transition-colors"
             >
-              Cancel
+              {t("Cancel")}
             </button>
           </div>
         </div>
@@ -841,7 +842,7 @@ function BulkDeleteDialog({
             onClick={onCancel}
             className="text-muted text-[12px] px-4 py-1.5 hover:text-foreground transition-colors"
           >
-            Cancel
+            {t("Cancel")}
           </button>
           {selectedAgent ? (
             <>
@@ -855,7 +856,7 @@ function BulkDeleteDialog({
                 onClick={onConfirm}
                 className="text-red-400 text-[12px] px-4 py-1.5 hover:text-red-300 transition-colors"
               >
-                Remove from all
+                {t("Remove from all")}
               </button>
             </>
           ) : (
@@ -946,7 +947,7 @@ function RemoveSkillDialog({ skill, onClose, onRemoveFromAgents, onRemoveAll }: 
             onClick={onClose}
             className="text-muted text-[12px] px-4 py-1.5 hover:text-foreground transition-colors"
           >
-            Cancel
+            {t("Cancel")}
           </button>
           <button
             onClick={() => {
@@ -955,13 +956,13 @@ function RemoveSkillDialog({ skill, onClose, onRemoveFromAgents, onRemoveAll }: 
             disabled={selectedAgents.length === 0}
             className="text-[12px] px-4 py-1.5 rounded-lg border border-border text-foreground hover:bg-surface-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
           >
-            Remove selected
+            {t("Remove selected")}
           </button>
           <button
             onClick={onRemoveAll}
             className="bg-red-600 text-white text-[12px] px-4 py-1.5 rounded-lg hover:bg-red-700 transition-colors"
           >
-            Remove all
+            {t("Remove all")}
           </button>
         </div>
       </div>
@@ -1135,7 +1136,7 @@ function RightPanel({
         <div className="text-center">
           <SkillsGateIcon />
           <p className="text-muted text-sm mt-3">
-            Select a skill to view details
+            {t("Select a skill to view details")}
           </p>
         </div>
       </div>
@@ -1157,16 +1158,16 @@ function RightPanel({
           </div>
           <div className="flex items-center gap-2">
             {saveStatus === "saved" && (
-              <span className="text-[12px] text-green-500">Saved</span>
+              <span className="text-[12px] text-green-500">{t("Saved")}</span>
             )}
             {saveStatus === "error" && (
-              <span className="text-[12px] text-red-500">Save failed</span>
+              <span className="text-[12px] text-red-500">{t("Save failed")}</span>
             )}
             <button
               onClick={handleCancel}
               className="rounded-lg border border-border px-4 py-2 text-[12px] text-muted transition-colors hover:text-foreground"
             >
-              Cancel
+              {t("Cancel")}
             </button>
             <button
               onClick={() => handleSave()}
@@ -1210,13 +1211,13 @@ function RightPanel({
                       onClick={() => { if (editMode) handleCancel() }}
                       className={`px-3 py-1.5 transition-colors ${!editMode ? "bg-surface-hover text-foreground font-medium" : "text-muted hover:text-foreground"}`}
                     >
-                      View
+                      {t("View")}
                     </button>
                     <button
                       onClick={() => { if (!editMode) handleEditToggle() }}
                       className={`px-3 py-1.5 transition-colors ${editMode ? "bg-surface-hover text-foreground font-medium" : "text-muted hover:text-foreground"}`}
                     >
-                      Edit
+                      {t("Edit")}
                     </button>
                   </div>
                 )}
@@ -1225,7 +1226,7 @@ function RightPanel({
                 {isLocalSkill && (
                   <button
                     onClick={handleOpenInFinder}
-                    title="Show in Finder"
+                    title={t("Show in Finder")}
                     className="p-1.5 rounded-md text-muted hover:text-foreground hover:bg-surface-hover transition-colors"
                   >
                     <FolderIcon />
@@ -1236,7 +1237,7 @@ function RightPanel({
                 {isLocalSkill && (
                   <button
                     onClick={handleDeleteClick}
-                    title="Remove skill"
+                    title={t("Remove skill")}
                     className="p-1.5 rounded-md text-muted hover:text-red-500 hover:bg-surface-hover transition-colors"
                   >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -1277,7 +1278,7 @@ function RightPanel({
             </p>
             <div className="mt-3">
               <div className="mb-2 flex items-center justify-between">
-                <p className="text-[10px] uppercase tracking-widest text-muted">Collections</p>
+                <p className="text-[10px] uppercase tracking-widest text-muted">{t("Collections")}</p>
                 <button
                   onClick={onCreateCollection}
                   className="text-[11px] text-muted hover:text-foreground"
@@ -1287,7 +1288,7 @@ function RightPanel({
               </div>
               <div className="flex flex-wrap gap-2">
                 {Object.keys(collections).length === 0 ? (
-                  <span className="text-[11px] text-muted">No collections yet.</span>
+                  <span className="text-[11px] text-muted">{t("No collections yet.")}</span>
                 ) : (
                   Object.entries(collections).map(([name, items]) => {
                     const included = items.includes(skill.canonicalPath)
@@ -1315,12 +1316,12 @@ function RightPanel({
 
           {/* Content: View or Edit mode */}
           {contentLoading ? (
-            <p className="text-sm text-muted animate-fade-in">Loading content...</p>
+            <p className="text-sm text-muted animate-fade-in">{t("Loading content...")}</p>
           ) : content ? (
             <MemoizedMarkdown content={content} />
           ) : (
             <p className="text-sm text-muted">
-              Skill content not available. This skill may not have a SKILL.md file.
+              {t("Skill content not available. This skill may not have a SKILL.md file.")}
             </p>
           )}
 
@@ -1330,7 +1331,7 @@ function RightPanel({
               <div className="grid grid-cols-[220px_1fr] gap-4">
                 <div>
                   <h2 className="text-[12px] uppercase tracking-widest text-muted mb-3">
-                    Supporting Files
+                    {t("Supporting Files")}
                   </h2>
                   <div className="flex flex-col gap-1">
                     {supportingFiles.map((file) => (
@@ -1351,7 +1352,7 @@ function RightPanel({
                 </div>
                 <div>
                   <h2 className="text-[12px] uppercase tracking-widest text-muted mb-3">
-                    Preview
+                    {t("Preview")}
                   </h2>
                   <pre className="min-h-[220px] overflow-x-auto rounded-lg border border-border bg-surface p-4 text-[12px] text-foreground whitespace-pre-wrap">
                     {supportingPreview || "Select a supporting file to preview it."}
@@ -1414,19 +1415,19 @@ function CreateSkillDialog({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="w-full max-w-lg rounded-xl border border-border bg-surface p-5 shadow-lg">
-        <h2 className="text-[15px] font-semibold text-foreground mb-1">New Skill</h2>
-        <p className="text-[12px] text-muted mb-4">Create a local skill and install it into one or more targets.</p>
+        <h2 className="text-[15px] font-semibold text-foreground mb-1">{t("New Skill")}</h2>
+        <p className="text-[12px] text-muted mb-4">{t("Create a local skill and install it into one or more targets.")}</p>
         <div className="flex flex-col gap-3">
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Skill name"
+            placeholder={t("Skill name")}
             className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[12px] text-foreground"
           />
           <textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="Short description"
+            placeholder={t("Short description")}
             className="min-h-[90px] w-full rounded-lg border border-border bg-background px-3 py-2 text-[12px] text-foreground"
           />
           <textarea
@@ -1445,7 +1446,7 @@ Add your skill instructions here.`}
             className="min-h-[220px] w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-[12px] text-foreground"
           />
           <div>
-            <p className="text-[12px] font-medium text-foreground mb-2">Targets</p>
+            <p className="text-[12px] font-medium text-foreground mb-2">{t("Targets")}</p>
             <div className="grid grid-cols-2 gap-2">
               {agents.map((agent) => (
                 <label key={agent.name} className="flex items-center gap-2 rounded-md border border-border px-3 py-2 text-[12px] text-foreground">
@@ -1460,13 +1461,13 @@ Add your skill instructions here.`}
             </div>
           </div>
           <div className="flex items-center justify-end gap-2">
-            <button onClick={onClose} className="px-4 py-2 text-[12px] text-muted">Cancel</button>
+            <button onClick={onClose} className="px-4 py-2 text-[12px] text-muted">{t("Cancel")}</button>
             <button
               onClick={() => onCreate({ name: name.trim(), description: description.trim(), content, targets })}
               disabled={!name.trim()}
               className="rounded-lg bg-foreground px-4 py-2 text-[12px] text-background disabled:opacity-40"
             >
-              Create
+              {t("Create")}
             </button>
           </div>
         </div>
@@ -1514,7 +1515,7 @@ function CollectionDialog({
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Collection name"
+            placeholder={t("Collection name")}
             className="w-full rounded-lg border border-border bg-background px-3 py-2 text-[12px] text-foreground"
             onKeyDown={(e) => {
               if (e.key === "Enter" && name.trim()) {
@@ -1524,7 +1525,7 @@ function CollectionDialog({
           />
           <div className="flex items-center justify-end gap-2">
             <button onClick={onClose} className="px-4 py-2 text-[12px] text-muted">
-              Cancel
+              {t("Cancel")}
             </button>
             <button
               onClick={() => onSubmit(name.trim())}

--- a/apps/desktop/src/renderer/routes/push-dialog.tsx
+++ b/apps/desktop/src/renderer/routes/push-dialog.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 // apps/desktop/src/renderer/routes/push-dialog.tsx
 import { useEffect, useState } from "react"
 
@@ -216,7 +217,7 @@ export function PushDialog({
               onClick={() => onClose()}
               className="px-3 py-1.5 rounded-lg text-[12px] font-medium text-foreground hover:bg-background transition-colors"
             >
-              Cancel
+              {t("Cancel")}
             </button>
           )}
 
@@ -240,7 +241,7 @@ export function PushDialog({
               onClick={() => onClose(result ?? undefined)}
               className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-foreground text-background hover:opacity-90 transition-opacity"
             >
-              Done
+              {t("Done")}
             </button>
           )}
         </div>

--- a/apps/desktop/src/renderer/routes/scan-sources.tsx
+++ b/apps/desktop/src/renderer/routes/scan-sources.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import { useEffect, useState } from "react"
 import { electronAPI } from "../lib/electron-api"
 
@@ -31,7 +32,7 @@ export function ScanSources() {
     <div className="flex-1 overflow-y-auto px-8 py-6">
       <div className="max-w-4xl">
         <div className="mb-6">
-          <h2 className="text-xl font-bold text-foreground mb-1">Scan Sources</h2>
+          <h2 className="text-xl font-bold text-foreground mb-1">{t("Scan Sources")}</h2>
           <p className="text-[12px] text-muted">
             Add folders that SkillsGate should crawl for direct skill bundles and project-local tool skill directories.
           </p>
@@ -41,7 +42,7 @@ export function ScanSources() {
           <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_0.8fr] gap-6">
             <div>
               <h3 className="text-[13px] font-semibold text-foreground mb-2">
-                Bring Your Own Skill Folders
+                {t("Bring Your Own Skill Folders")}
               </h3>
               <p className="text-[12px] text-muted leading-relaxed mb-4">
                 Point SkillsGate at places like `~/projects`, `~/workspaces`, or `~/my-skills`. It will discover:
@@ -59,17 +60,17 @@ export function ScanSources() {
             </div>
             <div className="rounded-xl border border-border bg-background p-4">
               <p className="text-[11px] uppercase tracking-widest text-muted mb-2">
-                Current Coverage
+                {t("Current Coverage")}
               </p>
               <div className="flex flex-col gap-2">
                 <div className="rounded-md border border-border px-3 py-2 text-[12px] text-foreground">
                   {paths.length} custom scan source{paths.length === 1 ? "" : "s"}
                 </div>
                 <div className="rounded-md border border-border px-3 py-2 text-[12px] text-foreground">
-                  Global installs still scanned automatically
+                  {t("Global installs still scanned automatically")}
                 </div>
                 <div className="rounded-md border border-border px-3 py-2 text-[12px] text-foreground">
-                  Project-local paths discovered under each root
+                  {t("Project-local paths discovered under each root")}
                 </div>
               </div>
             </div>
@@ -80,10 +81,10 @@ export function ScanSources() {
           <div className="flex items-center justify-between gap-3 mb-4">
             <div>
               <h3 className="text-[13px] font-semibold text-foreground">
-                Custom Roots
+                {t("Custom Roots")}
               </h3>
               <p className="text-[12px] text-muted">
-                Add and remove folders to include in local skill discovery.
+                {t("Add and remove folders to include in local skill discovery.")}
               </p>
             </div>
           </div>
@@ -114,7 +115,7 @@ export function ScanSources() {
               disabled={saving}
               className="rounded-lg bg-foreground px-4 py-2 text-[12px] font-medium text-background disabled:opacity-40"
             >
-              Add Root
+              {t("Add Root")}
             </button>
           </div>
 
@@ -141,7 +142,7 @@ export function ScanSources() {
                     onClick={() => void persist(paths.filter((item) => item !== scanPath))}
                     className="rounded-md border border-border px-3 py-1.5 text-[11px] text-red-400 hover:text-red-300 hover:bg-surface"
                   >
-                    Remove
+                    {t("Remove")}
                   </button>
                 </div>
               ))

--- a/apps/desktop/src/renderer/routes/server-skills.tsx
+++ b/apps/desktop/src/renderer/routes/server-skills.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import { useEffect, useState } from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import { marked } from "marked"
@@ -125,7 +126,7 @@ export function ServerSkills() {
             >
               <polyline points="15 18 9 12 15 6" />
             </svg>
-            Back to Servers
+            {t("Back to Servers")}
           </button>
           <h3 className="text-sm font-semibold text-foreground">
             {serverLabel}
@@ -140,7 +141,7 @@ export function ServerSkills() {
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <p className="text-[12px] text-muted animate-fade-in">
-                Loading skills...
+                {t("Loading skills...")}
               </p>
             </div>
           ) : skills.length === 0 ? (
@@ -159,10 +160,10 @@ export function ServerSkills() {
                 <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
               </svg>
               <p className="text-[12px] text-muted">
-                No skills found on this server.
+                {t("No skills found on this server.")}
               </p>
               <p className="text-[11px] text-muted mt-1">
-                Try syncing the server to discover skills.
+                {t("Try syncing the server to discover skills.")}
               </p>
             </div>
           ) : (
@@ -211,7 +212,7 @@ export function ServerSkills() {
                 <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
               </svg>
               <p className="text-muted text-sm mt-3">
-                Select a skill to view details
+                {t("Select a skill to view details")}
               </p>
             </div>
           </div>
@@ -268,10 +269,10 @@ export function ServerSkills() {
                   spellCheck={false}
                 />
                 {saveState === "saved" && (
-                  <p className="text-[12px] text-green-500">Saved</p>
+                  <p className="text-[12px] text-green-500">{t("Saved")}</p>
                 )}
                 {saveState === "error" && (
-                  <p className="text-[12px] text-red-500">Save failed</p>
+                  <p className="text-[12px] text-red-500">{t("Save failed")}</p>
                 )}
               </div>
             ) : selectedSkill.content ? (
@@ -283,7 +284,7 @@ export function ServerSkills() {
               />
             ) : (
               <p className="text-sm text-muted">
-                Skill content not cached. Sync the server to fetch content.
+                {t("Skill content not cached. Sync the server to fetch content.")}
               </p>
             )}
           </div>

--- a/apps/desktop/src/renderer/routes/servers.tsx
+++ b/apps/desktop/src/renderer/routes/servers.tsx
@@ -1,3 +1,4 @@
+import { t } from "../lib/i18n"
 import { useEffect, useState, useCallback, useRef } from "react"
 import { useNavigate } from "react-router-dom"
 import { electronAPI } from "../lib/electron-api"
@@ -152,7 +153,7 @@ function ServerDialog({
             {editingServer ? "Edit Server" : "Add Server"}
           </h3>
           <p className="text-[11px] text-muted mt-0.5">
-            Configure an SSH connection to discover remote skills.
+            {t("Configure an SSH connection to discover remote skills.")}
           </p>
         </div>
 
@@ -160,7 +161,7 @@ function ServerDialog({
           {/* Label */}
           <div>
             <label className="block text-[12px] font-medium text-foreground mb-1.5">
-              Label
+              {t("Label")}
             </label>
             <input
               type="text"
@@ -175,7 +176,7 @@ function ServerDialog({
           <div className="flex gap-3">
             <div className="flex-1">
               <label className="block text-[12px] font-medium text-foreground mb-1.5">
-                Host
+                {t("Host")}
               </label>
               <input
                 type="text"
@@ -187,7 +188,7 @@ function ServerDialog({
             </div>
             <div className="w-20">
               <label className="block text-[12px] font-medium text-foreground mb-1.5">
-                Port
+                {t("Port")}
               </label>
               <input
                 type="text"
@@ -202,7 +203,7 @@ function ServerDialog({
           {/* Username */}
           <div>
             <label className="block text-[12px] font-medium text-foreground mb-1.5">
-              Username
+              {t("Username")}
             </label>
             <input
               type="text"
@@ -216,7 +217,7 @@ function ServerDialog({
           {/* Skills Base Path */}
           <div>
             <label className="block text-[12px] font-medium text-foreground mb-1.5">
-              Skills Base Path
+              {t("Skills Base Path")}
             </label>
             <input
               type="text"
@@ -232,12 +233,12 @@ function ServerDialog({
           {/* SSH Key Path */}
           <div>
             <label className="block text-[12px] font-medium text-foreground mb-1.5">
-              SSH Key Path
+              {t("SSH Key Path")}
               <span className="font-normal text-muted ml-1">(optional)</span>
             </label>
             <input
               type="text"
-              placeholder="Auto-discover (id_ed25519, id_rsa, ...)"
+              placeholder={t("Auto-discover (id_ed25519, id_rsa, ...)")}
               value={form.sshKeyPath}
               onChange={(e) =>
                 setForm({ ...form, sshKeyPath: e.target.value })
@@ -253,7 +254,7 @@ function ServerDialog({
               onClick={onClose}
               className="px-4 py-2 rounded-lg text-[12px] font-medium border border-border text-muted hover:text-foreground hover:bg-surface-hover transition-colors"
             >
-              Cancel
+              {t("Cancel")}
             </button>
             <button
               type="submit"
@@ -485,7 +486,7 @@ export function Servers() {
   return (
     <div className="p-8">
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-xl font-bold text-foreground">Remote Servers</h2>
+        <h2 className="text-xl font-bold text-foreground">{t("Remote Servers")}</h2>
         <button
           onClick={openAdd}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium bg-foreground text-background hover:opacity-90 transition-opacity"
@@ -503,17 +504,17 @@ export function Servers() {
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
-          Add Server
+          {t("Add Server")}
         </button>
       </div>
       <p className="text-[12px] text-muted mb-6">
-        Connect to remote machines via SSH to discover and sync skills.
+        {t("Connect to remote machines via SSH to discover and sync skills.")}
       </p>
 
       {loading ? (
         <div className="flex items-center justify-center py-16">
           <p className="text-[12px] text-muted animate-fade-in">
-            Loading servers...
+            {t("Loading servers...")}
           </p>
         </div>
       ) : servers.length === 0 ? (
@@ -534,15 +535,15 @@ export function Servers() {
             <line x1="6" y1="6" x2="6.01" y2="6" />
             <line x1="6" y1="18" x2="6.01" y2="18" />
           </svg>
-          <p className="text-sm text-muted">No servers configured.</p>
+          <p className="text-sm text-muted">{t("No servers configured.")}</p>
           <p className="text-[11px] text-muted mt-1">
-            Add a server to discover skills from remote machines.
+            {t("Add a server to discover skills from remote machines.")}
           </p>
           <button
             onClick={openAdd}
             className="mt-4 px-4 py-2 rounded-lg text-[12px] font-medium bg-foreground text-background hover:opacity-90 transition-opacity"
           >
-            Add your first server
+            {t("Add your first server")}
           </button>
         </div>
       ) : (
@@ -611,15 +612,15 @@ export function Servers() {
                 <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                   <button
                     onClick={() => navigate(`/servers/${server.id}/skills`)}
-                    title="Browse skills"
+                    title={t("Browse skills")}
                     className="px-2 py-1.5 rounded-md text-[11px] font-medium text-muted hover:text-foreground hover:bg-background transition-colors"
                   >
-                    Browse
+                    {t("Browse")}
                   </button>
                   <button
                     onClick={() => handleTest(server.id)}
                     disabled={isTesting}
-                    title="Test connection"
+                    title={t("Test connection")}
                     className="px-2 py-1.5 rounded-md text-[11px] font-medium text-muted hover:text-foreground hover:bg-background transition-colors disabled:opacity-40"
                   >
                     {isTesting ? "..." : "Test"}
@@ -632,24 +633,24 @@ export function Servers() {
                       setManageOpenFor((prev) => (prev === server.id ? null : server.id))
                     }
                     disabled={isSyncing}
-                    title="Manage this server"
+                    title={t("Manage this server")}
                     className="px-2.5 py-1 rounded-md text-[11px] font-medium border border-border text-foreground hover:bg-background transition-colors disabled:opacity-40"
                   >
                     {isSyncing ? "Syncing..." : "Manage ▾"}
                   </button>
                   <button
                     onClick={() => openEdit(server)}
-                    title="Edit server"
+                    title={t("Edit server")}
                     className="px-2 py-1.5 rounded-md text-[11px] font-medium text-muted hover:text-foreground hover:bg-background transition-colors"
                   >
-                    Edit
+                    {t("Edit")}
                   </button>
                   <button
                     onClick={() => handleDelete(server.id)}
-                    title="Delete server"
+                    title={t("Delete server")}
                     className="px-2 py-1.5 rounded-md text-[11px] font-medium text-red-400 hover:text-red-300 hover:bg-background transition-colors"
                   >
-                    Delete
+                    {t("Delete")}
                   </button>
                 </div>
                 </div>

--- a/apps/desktop/src/renderer/routes/settings.tsx
+++ b/apps/desktop/src/renderer/routes/settings.tsx
@@ -1,3 +1,4 @@
+import { LOCALES, changeLocale, getLocale, t, type Locale } from "../lib/i18n"
 import { useState, useEffect, useCallback } from "react"
 import { electronAPI } from "../lib/electron-api"
 
@@ -91,6 +92,9 @@ export function Settings() {
   const [updateState, setUpdateState] = useState<UpdateState | null>(null)
   const [checkingUpdates, setCheckingUpdates] = useState(false)
   const [settingsLoaded, setSettingsLoaded] = useState(false)
+  // Locale lives in the i18n module, not in settingsAll(), because it must be
+  // resolved before the first render. Seed from there.
+  const [locale, setLocaleChoice] = useState<Locale>(getLocale())
 
   const loadSettings = useCallback(async () => {
     try {
@@ -167,22 +171,44 @@ export function Settings() {
 
   return (
     <div className="p-8">
-      <h2 className="text-xl font-bold text-foreground mb-1">Settings</h2>
+      <h2 className="text-xl font-bold text-foreground mb-1">{t("Settings")}</h2>
       <p className="text-[12px] text-muted mb-6">
-        Configure your SkillsGate Desktop preferences.
+        {t("Configure your SkillsGate Desktop preferences.")}
       </p>
 
       <div className="flex flex-col gap-6 max-w-lg">
+        {/* Language */}
+        <section>
+          <h3 className="text-sm font-semibold text-foreground mb-3">
+            {t("Language")}
+          </h3>
+          <SettingSelect
+            label={t("Display language")}
+            description={t(
+              "Applies immediately. Untranslated text stays in English.",
+            )}
+            value={locale}
+            options={LOCALES.map((entry) => ({
+              value: entry.code,
+              label: entry.label,
+            }))}
+            onChange={(v) => {
+              setLocaleChoice(v as Locale)
+              changeLocale(v as Locale)
+            }}
+          />
+        </section>
+
         {/* Install preferences */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Installation
+            {t("Installation")}
           </h3>
           <div className="flex flex-col gap-3">
             {settingsLoaded ? (
               <>
                 <SettingSelect
-                  label="Default scope"
+                  label={t("Default scope")}
                   description="Where skills are installed by default"
                   value={installScope}
                   options={[
@@ -195,7 +221,7 @@ export function Settings() {
                   }}
                 />
                 <SettingSelect
-                  label="Install method"
+                  label={t("Install method")}
                   description="How skill files are placed in agent directories"
                   value={installMethod}
                   options={[
@@ -219,12 +245,12 @@ export function Settings() {
         {/* Search preferences */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Search
+            {t("Search")}
           </h3>
           <div className="flex flex-col gap-3">
             {settingsLoaded && (
               <SettingSelect
-                label="Search preference"
+                label={t("Search preference")}
                 description="Preferred search method for discovering skills"
                 value={searchPreference}
                 options={[
@@ -243,12 +269,12 @@ export function Settings() {
         {/* Privacy */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Privacy
+            {t("Privacy")}
           </h3>
           <div className="flex flex-col gap-3">
             {settingsLoaded && (
               <SettingToggle
-                label="Telemetry"
+                label={t("Telemetry")}
                 description="Send anonymous usage data to help improve SkillsGate"
                 value={telemetryEnabled}
                 onChange={(v) => {
@@ -263,12 +289,12 @@ export function Settings() {
         {/* Updates */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Updates
+            {t("Updates")}
           </h3>
           <div className="rounded-lg border border-border bg-surface p-4">
             <div className="flex items-start justify-between gap-4">
               <div>
-                <p className="text-sm text-foreground">Desktop app updates</p>
+                <p className="text-sm text-foreground">{t("Desktop app updates")}</p>
                 <p className="text-[11px] text-muted mt-1">
                   Version {appVersion || "unknown"}
                 </p>
@@ -299,7 +325,7 @@ export function Settings() {
                     onClick={() => electronAPI.updatesInstall()}
                     className="rounded-lg bg-foreground px-4 py-2 text-[12px] font-medium text-background"
                   >
-                    Restart to install
+                    {t("Restart to install")}
                   </button>
                 )}
               </div>
@@ -310,11 +336,11 @@ export function Settings() {
         {/* Scan paths */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Scan Paths
+            {t("Scan Paths")}
           </h3>
           <div className="flex flex-col gap-3">
             <div className="rounded-lg border border-border bg-surface p-3">
-              <p className="text-sm text-foreground mb-1">Custom scan directories</p>
+              <p className="text-sm text-foreground mb-1">{t("Custom scan directories")}</p>
               <p className="text-[11px] text-muted mb-3">
                 SkillsGate will scan direct skill folders and project-local tool paths inside these roots.
               </p>
@@ -337,12 +363,12 @@ export function Settings() {
                   }}
                   className="px-3 py-2 rounded-lg bg-foreground text-background text-[12px] font-medium"
                 >
-                  Add
+                  {t("Add")}
                 </button>
               </div>
               <div className="flex flex-col gap-2">
                 {customScanPaths.length === 0 ? (
-                  <p className="text-[11px] text-muted">No custom scan paths configured.</p>
+                  <p className="text-[11px] text-muted">{t("No custom scan paths configured.")}</p>
                 ) : (
                   customScanPaths.map((scanPath) => (
                     <div key={scanPath} className="flex items-center justify-between rounded-md border border-border px-3 py-2">
@@ -355,7 +381,7 @@ export function Settings() {
                         }}
                         className="text-[11px] text-red-400 hover:text-red-300"
                       >
-                        Remove
+                        {t("Remove")}
                       </button>
                     </div>
                   ))
@@ -368,10 +394,10 @@ export function Settings() {
         {/* Target defaults */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Default Targets
+            {t("Default Targets")}
           </h3>
           <div className="rounded-lg border border-border bg-surface p-3">
-            <p className="text-sm text-foreground mb-1">Install targets</p>
+            <p className="text-sm text-foreground mb-1">{t("Install targets")}</p>
             <p className="text-[11px] text-muted mb-3">
               These targets are used for installs and new local skill creation when no explicit target set is chosen.
             </p>
@@ -395,10 +421,10 @@ export function Settings() {
         {/* Sync rules */}
         <section>
           <h3 className="text-sm font-semibold text-foreground mb-3">
-            Sync Rules
+            {t("Sync Rules")}
           </h3>
           <div className="rounded-lg border border-border bg-surface p-3">
-            <p className="text-sm text-foreground mb-1">Mirror installs to additional targets</p>
+            <p className="text-sm text-foreground mb-1">{t("Mirror installs to additional targets")}</p>
             <p className="text-[11px] text-muted mb-3">
               Any skill installed or created in the desktop app will also be linked into these targets.
             </p>
@@ -421,13 +447,13 @@ export function Settings() {
 
         {/* About */}
         <section>
-          <h3 className="text-sm font-semibold text-foreground mb-3">About</h3>
+          <h3 className="text-sm font-semibold text-foreground mb-3">{t("About")}</h3>
           <div className="p-3 rounded-lg border border-border bg-surface">
             <p className="text-sm text-foreground">
               SkillsGate Desktop v{appVersion || "0.1.6"}
             </p>
             <p className="text-[11px] text-muted mt-1">
-              Manage AI agent skills from your desktop.
+              {t("Manage AI agent skills from your desktop.")}
             </p>
           </div>
         </section>


### PR DESCRIPTION
Part of #23. Implements items 1–4 of the plan you approved there; the drift script (item 5) follows in a separate PR, as sequenced.

Scope is `apps/desktop` only — per your call, `apps/web` is out, and `tui`/`cli` come later with their own resolution.

## What this adds

| | |
|---|---|
| `locales/index.ts` | The locale registry — the single extension point |
| `lib/i18n.ts` | Resolver, dictionary lookup, locale subscription |
| Settings → Language | A selector populated from the registry |
| `locales/zh-CN.ts` | The Simplified Chinese dictionary, rebased on current `main` |

## Adding a language is one file plus one line

```ts
export const LOCALES = [
  { code: "en",    label: "English",  dict: {} },
  { code: "zh-CN", label: "简体中文",  dict: zhCN },
  // a contributor adds one line here
] as const satisfies ...

export type Locale = (typeof LOCALES)[number]["code"]
```

The `Locale` type is derived from that array, and the selector and resolver both enumerate from it, so a contributor never touches `lib/i18n.ts` or any component. Entries carry the endonym (`简体中文`, not "Chinese") — that is what people scan for in a language menu.

**Keys are the English source string.** A miss falls back to the key, so an untranslated string renders as English, never as a missing-key placeholder. That is the mechanism that makes a *partial* translation shippable: someone can land 40 strings of Portuguese without breaking the UI. The `en` dict is empty by definition, so English is always 100% complete and needs no maintenance.

## Locale resolution

Saved preference → system locale (exact, e.g. `pt-BR`, then base language `pt`) → `en`. `main.tsx` awaits this before the first render, so the UI never flashes English before switching.

The preference uses the settings channel that already exists (`settingsGet`/`settingsSet`, same store as `scan.customPaths`) under `ui.locale`. **No new IPC surface, no new dependency** — `package.json` and the lockfile are untouched.

## Two deviations worth calling out

1. **System locale comes from `navigator.language`, not `app.getLocale()`.** The issue said the latter; reading it in the renderer is what keeps the "no new IPC surface" promise, and both resolve from the same Chromium locale. Happy to switch if you'd rather have the main-process value.

2. **The app root is keyed on the current locale.** `t()` is a plain function, so the eight `memo`ised components would otherwise keep rendering the previous language until their props happened to change. Re-keying makes a switch apply immediately without reloading the window.

Related: sidebar nav labels are translated at the render site rather than inside the `navItems` constant — that array is module level, so calling `t()` there would bind one language at import time. The labels stay English in the data, which is consistent with keys being source strings.

## Coverage

| | count |
|---|---|
| unique `t()` call sites in `apps/desktop` | 130 |
| entries in `zh-CN` | 130 |
| missing (would fall back to English) | 0 |
| orphaned (translated, no longer called) | 0 |

The one orphaned entry I reported in the issue (`Save`) is removed here.

Not covered: the `description` text on existing settings rows is not wrapped in `t()` upstream, so it still renders English in any locale. Widening coverage is a separate change and I left it out deliberately to keep this PR reviewable as one feature.

## Verification

Renderer typecheck introduces no new errors — the four pre-existing `home.tsx` errors are identical on `main` (verified against a clean `origin/main` worktree). `npm run build` in `apps/desktop` passes.

Behaviour checked in a running app over the devtools protocol:

- No saved preference + `zh-CN` system locale → UI starts translated (resolver falls through to the system value).
- Switching to English updates the sidebar, the memoised home panels and the settings page with no reload.
- The choice persists to `ui.locale` and survives a restart; on relaunch the selector reads back `en` and the UI starts English.

## Next

PR 2 will add the drift script (missing/orphaned key diff, exit non-zero on request so it can gate CI) plus a short `locales/README.md` telling a contributor exactly what to do. Happy to fold it in here instead if you'd rather review once.
